### PR TITLE
Checkbox

### DIFF
--- a/src/components/Checkbox.spec.tsx
+++ b/src/components/Checkbox.spec.tsx
@@ -1,0 +1,18 @@
+import { Checkbox } from './Checkbox';
+import renderer from 'react-test-renderer';
+
+describe('Checkbox', () => {
+  it('matches snapshot', () => {
+    const tree = renderer.create(
+      <Checkbox>Click Me</Checkbox>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('handles options', () => {
+    const tree = renderer.create(
+      <Checkbox bold size={2} variant='light'>Click Me</Checkbox>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/Checkbox.stories.tsx
+++ b/src/components/Checkbox.stories.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+import { Checkbox } from "./Checkbox";
+
+const CheckboxGroup = styled.div`
+  text-transform: capitalize;
+  & + & {
+    margin-top: 3.2rem;
+  }
+  > * + * {
+    margin-top: 0.5rem;
+  }
+`;
+
+type CheckboxProps = React.ComponentProps<typeof Checkbox>;
+const renderCheckboxes = (variant: CheckboxProps['variant'], size: CheckboxProps['size']) => <CheckboxGroup>
+  <h2>Size {size}</h2>
+  <Checkbox {...{size, variant}}>Checkbox label</Checkbox>
+  <Checkbox {...{size, variant}} defaultChecked>Checkbox label</Checkbox>
+  <Checkbox {...{size, variant}} defaultChecked bold>Checkbox label</Checkbox>
+</CheckboxGroup>;
+
+export const Primary = () => <>
+  {renderCheckboxes('primary', 1.4)}
+  {renderCheckboxes('primary', 1.6)}
+  {renderCheckboxes('primary', 1.8)}
+  {renderCheckboxes('primary', 2)}
+</>;
+
+export const Light = () => <>
+  {renderCheckboxes('light', 1.4)}
+  {renderCheckboxes('light', 1.6)}
+  {renderCheckboxes('light', 1.8)}
+  {renderCheckboxes('light', 2)}
+</>

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -35,12 +35,11 @@ const StyledInput = styled.input<{ variant: CheckboxVariant; checkboxSize: Check
 `;
 
 type CheckboxProps = PropsWithChildren<
-  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
-> & {
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> & {
   variant?: CheckboxVariant;
   size?: CheckboxSize;
   bold?: boolean;
-};
+}>;
 
 export const Checkbox = ({ children, variant = 'primary', bold = false, size = 1.6, ...props }: CheckboxProps) => {
   return (

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,52 @@
+import { PropsWithChildren } from "react";
+import { colors } from "../theme";
+import styled from "styled-components";
+import { InputHTMLAttributes } from "react";
+
+type CheckboxVariant = keyof typeof checkboxVariants;
+type CheckboxSize = 1.4 | 1.6 | 1.8 | 2;
+
+export const checkboxVariants = {
+  primary: {
+    accentColor: colors.palette.mediumBlue,
+    boxShadow: 'none',
+  },
+  light: {
+    accentColor: colors.palette.white,
+    boxShadow: '0 0 1px 0',
+  }
+} as const;
+
+const StyledLabel = styled.label<{ bold: boolean; }>`
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  font-weight: ${props => props.bold ? 700 : 400}
+`;
+
+const StyledInput = styled.input<{ variant: CheckboxVariant; checkboxSize: CheckboxSize; }>`
+  accent-color: ${props => checkboxVariants[props.variant].accentColor};
+  width: ${props => props.checkboxSize}rem;
+  height: ${props => props.checkboxSize}rem;
+  margin: 0 1.6rem 0 0;
+  &:checked {
+    box-shadow: ${props => checkboxVariants[props.variant].boxShadow};
+  }
+`;
+
+type CheckboxProps = PropsWithChildren<
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+> & {
+  variant?: CheckboxVariant;
+  size?: CheckboxSize;
+  bold?: boolean;
+};
+
+export const Checkbox = ({ children, variant = 'primary', bold = false, size = 1.6, ...props }: CheckboxProps) => {
+  return (
+    <StyledLabel bold={bold}>
+      <StyledInput {...props} type="checkbox" variant={variant} checkboxSize={size} />
+      {children}
+    </StyledLabel>
+  );
+};

--- a/src/components/__snapshots__/Checkbox.spec.tsx.snap
+++ b/src/components/__snapshots__/Checkbox.spec.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Checkbox handles options 1`] = `
+<label
+  className="sc-bczRLJ bYTfrb"
+>
+  <input
+    className="sc-gsnTZi hvmWuC"
+    type="checkbox"
+  />
+  Click Me
+</label>
+`;
+
+exports[`Checkbox matches snapshot 1`] = `
+<label
+  className="sc-bczRLJ bYTeUU"
+>
+  <input
+    className="sc-gsnTZi ljReaQ"
+    type="checkbox"
+  />
+  Click Me
+</label>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export * from './components/ToastContainer';
 export * from './components/Loader';
 export * from './components/NavBar';
 export * from './components/NavBarLogo';
-export * from './types';
+export * from './components/Checkbox';
 export * from './theme';
+export * from './types';


### PR DESCRIPTION
Uses `accent-color` instead of SVG workarounds because it seems to have decent support now: https://caniuse.com/mdn-css_properties_accent-color There is one quirk I found when setting it to white and checked, no border is rendered so with that accent-color it only shows the checkmark itself, that's why the `box-shadow` workaround is there. Doesn't feel ideal though and I wonder if there's a better workaround.

Also not sure how much I like the bold/size interface here. I thought it would be nice to not need to override styles for some common use cases but not sure how I feel about it.