### PR TITLE
Hacks

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,0 +1,13 @@
+import { ModalBody, ModalBodyHeading } from "./Modal";
+
+export interface ErrorPropTypes {
+  className?: string;
+}
+
+export const Error = (props: ErrorPropTypes) => {
+  return <ModalBody {...props}>
+    <ModalBodyHeading>Uh-oh, there's been a glitch</ModalBodyHeading>
+    We're not quite sure what went wrong. Restart your browser. If this doesn't solve
+    the problem, visit our <a href="https://openstax.secure.force.com/help" target="_blank">Support Center</a>.
+  </ModalBody>
+};

--- a/src/components/ErrorModal.tsx
+++ b/src/components/ErrorModal.tsx
@@ -1,15 +1,12 @@
 import { Button } from "./Button";
-import { Modal, ModalBody, ModalBodyHeading, ModalFooter, ModalPropTypes } from "./Modal";
+import { Modal, ModalFooter, ModalPropTypes } from "./Modal";
+import { Error } from "./Error";
 
 type ErrorModalProps = React.PropsWithChildren<Omit<ModalPropTypes, 'variant' | 'heading'>>;
 
 export const ErrorModal = (props: ErrorModalProps) => {
   return <Modal {...props} variant='error' heading='Error'>
-    <ModalBody>
-      <ModalBodyHeading>Uh-oh, there's been a glitch</ModalBodyHeading>
-      We're not quite sure what went wrong. Restart your browser. If this doesn't solve
-      the problem, visit our <a href="https://openstax.secure.force.com/help" target="_blank">Support Center</a>.
-    </ModalBody>
+    <Error />
     <ModalFooter><Button onClick={props.onModalClose}>OK</Button></ModalFooter>
   </Modal>;
 };

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -137,7 +137,7 @@ export const Loader = (props: Props) => (
     id='Layer_1'
     x='0px'
     y='0px'
-    viewBox='0 0 57.6 39.1'
+    viewBox='0 -30 57.6 69.1'
     {...props}
   >
     <path

--- a/src/components/__snapshots__/Loader.spec.tsx.snap
+++ b/src/components/__snapshots__/Loader.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Loader matches large snapshot 1`] = `
   data-testid="loader"
   id="Layer_1"
   version="1.1"
-  viewBox="0 0 57.6 39.1"
+  viewBox="0 -30 57.6 69.1"
   x="0px"
   y="0px"
 >
@@ -79,7 +79,7 @@ exports[`Loader matches snapshot 1`] = `
   data-testid="loader"
   id="Layer_1"
   version="1.1"
-  viewBox="0 0 57.6 39.1"
+  viewBox="0 -30 57.6 69.1"
   x="0px"
   y="0px"
 >

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './components/Error';
 export * from './components/Modal';
 export * from './components/ErrorModal';
 export * from './components/Button';


### PR DESCRIPTION
i'm not proud of the usage of the modal components outside of the modal, but i needed something like the dialog display but not in a dialog, and it worked perfectly.

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/636227/216695150-2ebc7dbe-bd95-4850-9b5b-795027adca7d.png">

if we want we can at some point replace that component with non-modal styles, but i like having the component in the public api.

the loader fix is so that the top doesn't get cut off if extra vertical space isn't reserved for it

