### PR TITLE
Link button

### DIFF
--- a/src/components/Button.spec.tsx
+++ b/src/components/Button.spec.tsx
@@ -29,4 +29,11 @@ describe('Button', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders as a tag variant', () => {
+    const tree = renderer.create(
+      <LinkButton variant='light'>Click Me</LinkButton>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/Button.spec.tsx
+++ b/src/components/Button.spec.tsx
@@ -1,4 +1,4 @@
-import { Button } from './Button';
+import { Button, LinkButton } from './Button';
 import renderer from 'react-test-renderer';
 
 describe('Button', () => {
@@ -19,6 +19,13 @@ describe('Button', () => {
   it('isWaiting state matches snapshot', () => {
     const tree = renderer.create(
       <Button isWaiting={true} waitingText="Submitting...">Click Me</Button>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders as a tag', () => {
+    const tree = renderer.create(
+      <LinkButton>Click Me</LinkButton>
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "./Button";
+import { Button, LinkButton } from "./Button";
 
 export const Primary = () => <>
   <Button>Primary</Button>
@@ -16,4 +16,9 @@ export const Secondary = () => <>
   <Button variant='secondary'>Secondary</Button>
   <Button variant='secondary' disabled>Disabled</Button>
   <Button variant='secondary' isWaiting={true} waitingText='Waiting...'>Button</Button>
+</>;
+
+export const Link = () => <>
+  <LinkButton href='https://openstax.org'>Primary</LinkButton>
+  <LinkButton variant='secondary' href='https://openstax.org' target='_blank'>Button</LinkButton>
 </>;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -36,6 +36,7 @@ const StyledButton = styled.button<{ variant: ButtonVariant }>`
 
 interface ButtonBase extends React.ComponentPropsWithoutRef<'button'> {
   variant?: ButtonVariant;
+  link?: boolean;
 }
 
 interface ButtonProps extends ButtonBase {
@@ -62,7 +63,12 @@ export const Button = (props: ButtonProps | WaitingButtonProps) => {
     {...otherProps}
     disabled={isWaiting || disabled}
     variant={variant}
+    as={props.link ? 'a' : 'button'}
   >
     {(isWaiting && waitingText) || children}
   </StyledButton>;
 }
+export const LinkButton = (
+  props: Omit<React.ComponentPropsWithoutRef<'a'> & ButtonProps, 'disabled' | 'link'>
+) =>
+  <Button {...props} link={true}>{props.children}</Button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -34,10 +34,12 @@ const StyledButton = styled.button<{ variant: ButtonVariant }>`
   }
 `;
 
-interface ButtonBase extends React.ComponentPropsWithoutRef<'button'> {
+interface ButtonOptions {
   variant?: ButtonVariant;
-  link?: boolean;
 }
+
+type ButtonBase = React.ComponentPropsWithoutRef<'button'> & ButtonOptions;
+type LinkButtonBase = React.ComponentPropsWithoutRef<'a'> & ButtonOptions;
 
 interface ButtonProps extends ButtonBase {
   isWaiting?: never;
@@ -63,12 +65,10 @@ export const Button = (props: ButtonProps | WaitingButtonProps) => {
     {...otherProps}
     disabled={isWaiting || disabled}
     variant={variant}
-    as={props.link ? 'a' : 'button'}
   >
     {(isWaiting && waitingText) || children}
   </StyledButton>;
 }
-export const LinkButton = (
-  props: Omit<React.ComponentPropsWithoutRef<'a'> & ButtonProps, 'disabled' | 'link'>
-) =>
-  <Button {...props} link={true}>{props.children}</Button>
+
+export const LinkButton = ({ variant = 'primary', ...props}: LinkButtonBase) =>
+  <StyledButton {...props} as='a' variant={variant}>{props.children}</StyledButton>

--- a/src/components/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/__snapshots__/Button.spec.tsx.snap
@@ -32,3 +32,11 @@ exports[`Button renders as a tag 1`] = `
   Click Me
 </a>
 `;
+
+exports[`Button renders as a tag variant 1`] = `
+<a
+  className="sc-bczRLJ gWva-dl"
+>
+  Click Me
+</a>
+`;

--- a/src/components/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/__snapshots__/Button.spec.tsx.snap
@@ -24,3 +24,11 @@ exports[`Button matches snapshot 1`] = `
   Click Me
 </button>
 `;
+
+exports[`Button renders as a tag 1`] = `
+<a
+  className="sc-bczRLJ cJphOo"
+>
+  Click Me
+</a>
+`;


### PR DESCRIPTION
Realized we need to sometimes render buttons as an `a` tag for behavior reasons. I ran into a lot of issues exposing the style-component props, and ended up adding a separate component instead. I'm not 100% sure of this interface though.