### PR TITLE
Render event id when promise rejection event occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ladle/react": "^2.1.2",
     "@openstax/ts-utils": "^1.1.42",
     "@playwright/test": "^1.25.0",
+    "@testing-library/react": "12",
     "@types/jest": "^28.1.4",
     "@types/node": "^18.7.5",
     "@types/node-fetch": "^2.6.2",

--- a/src/components/Error.spec.tsx
+++ b/src/components/Error.spec.tsx
@@ -1,5 +1,7 @@
 import renderer from 'react-test-renderer';
+import { render, act } from '@testing-library/react';
 import { Error } from './Error';
+import * as Sentry from '@sentry/react';
 
 describe('Error', () => {
   it('matches snapshot', () => {
@@ -14,5 +16,26 @@ describe('Error', () => {
       <Error heading='An important heading'>Body text</Error>
     ).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('updates lastEventId when Sentry.lastEventId() changes', async () => {
+    jest.useFakeTimers();
+
+    const sentrySpy = jest.spyOn(Sentry, 'lastEventId');
+    sentrySpy.mockReturnValue('initialEventId');
+
+    const { getByTestId } = render(<Error heading='test' />);
+
+    const errorElement = getByTestId('error');
+    expect(errorElement.textContent).toContain('initialEventId');
+
+    act(() => {
+      sentrySpy.mockReturnValue('updatedEventId');
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(errorElement.textContent).toContain('updatedEventId');
+
+    jest.restoreAllMocks();
   });
 });

--- a/src/components/Error.spec.tsx
+++ b/src/components/Error.spec.tsx
@@ -21,13 +21,15 @@ describe('Error', () => {
   it('updates lastEventId when Sentry.lastEventId() changes', async () => {
     jest.useFakeTimers();
 
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
     const sentrySpy = jest.spyOn(Sentry, 'lastEventId');
-    sentrySpy.mockReturnValue('initialEventId');
+    sentrySpy.mockReturnValue(undefined);
 
-    const { getByTestId } = render(<Error heading='test' />);
+    const { getByTestId } = render(<Error />);
 
-    const errorElement = getByTestId('error');
-    expect(errorElement.textContent).toContain('initialEventId');
+    const errorElement = getByTestId('event-id');
+    expect(errorElement.textContent).toBe('');
+    expect(setIntervalSpy).toHaveBeenCalled();
 
     act(() => {
       sentrySpy.mockReturnValue('updatedEventId');

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -22,7 +22,7 @@ export const Error = ({ heading, children, ...props }: ErrorPropTypes) => {
   const [lastEventId, setLastEventId] = React.useState<string | undefined>(Sentry.lastEventId());
 
   React.useEffect(() => {
-    if (context?.eventId) {
+    if (context?.eventId || lastEventId) {
       return;
     }
 
@@ -42,6 +42,6 @@ export const Error = ({ heading, children, ...props }: ErrorPropTypes) => {
       We're not quite sure what went wrong. Restart your browser. If this doesn't solve
       the problem, visit our <a href="https://openstax.secure.force.com/help" target="_blank">Support Center</a>.
     </>}
-    <EventId>{context?.eventId || lastEventId}</EventId>
+    <EventId data-testid='event-id'>{context?.eventId || lastEventId}</EventId>
   </ModalBody>
 };

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -19,11 +19,22 @@ const EventId = styled.div`
 
 export const Error = ({ heading, children, ...props }: ErrorPropTypes) => {
   const context = React.useContext(ErrorContext);
-  const [lastEventId, setLastEventId] = React.useState<string | undefined>();
+  const [lastEventId, setLastEventId] = React.useState<string | undefined>(Sentry.lastEventId());
 
   React.useEffect(() => {
-    setLastEventId(Sentry.lastEventId());
-  }, [Sentry.lastEventId()]);
+    if (context?.eventId) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      const currentEventId = Sentry.lastEventId();
+      if (lastEventId !== currentEventId) {
+        setLastEventId(currentEventId);
+      }
+    }, 100);
+
+    return () => clearInterval(intervalId);
+  }, [lastEventId, context?.eventId]);
 
   return <ModalBody {...props} data-testid='error'>
     <ModalBodyHeading>{heading ?? `Uh-oh, there's been a glitch`}</ModalBodyHeading>

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Sentry from '@sentry/react';
 import { ModalBody, ModalBodyHeading } from "./Modal";
 import styled from "styled-components";
 import { colors } from "../../src/theme";
@@ -11,13 +12,18 @@ export interface ErrorPropTypes {
 }
 
 const EventId = styled.div`
-  font-size: 0.9rem;
+  font-size: 1.4rem;
   color: ${colors.palette.neutralMedium};
-  margin-top: 1.2rem;
+  margin-top: 1.6rem;
 `;
 
 export const Error = ({ heading, children, ...props }: ErrorPropTypes) => {
   const context = React.useContext(ErrorContext);
+  const [lastEventId, setLastEventId] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    setLastEventId(Sentry.lastEventId());
+  }, [Sentry.lastEventId()]);
 
   return <ModalBody {...props} data-testid='error'>
     <ModalBodyHeading>{heading ?? `Uh-oh, there's been a glitch`}</ModalBodyHeading>
@@ -25,6 +31,6 @@ export const Error = ({ heading, children, ...props }: ErrorPropTypes) => {
       We're not quite sure what went wrong. Restart your browser. If this doesn't solve
       the problem, visit our <a href="https://openstax.secure.force.com/help" target="_blank">Support Center</a>.
     </>}
-    <EventId>{context?.eventId}</EventId>
+    <EventId>{context?.eventId || lastEventId}</EventId>
   </ModalBody>
 };

--- a/src/components/ErrorBoundary.spec.tsx
+++ b/src/components/ErrorBoundary.spec.tsx
@@ -16,6 +16,10 @@ describe('ErrorBoundary', () => {
       transport: sentryTransport,
     });
 
+    jest.spyOn(Sentry, 'lastEventId').mockReturnValue('someuuid');
+  });
+
+  afterEach(() => {
     jest.resetAllMocks();
   });
 

--- a/src/components/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary.stories.tsx
@@ -41,7 +41,7 @@ export const InlineMessages = () => {
 export const Fallback_GenericError_Default = () => {
   const [showError, setShowError] = React.useState(false);
 
-  return <ErrorBoundary renderFallback>
+  return <ErrorBoundary renderFallback sentryDsn="https://0@o0.ingest.sentry.io/0">
     <ErrorComponent
       doThrow={showError}
       setShowError={setShowError}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -74,8 +74,7 @@ export const ErrorBoundary = ({
           name: e.type,
           message: e.reason?.toString(),
         },
-        type: getTypeFromError(e.reason),
-        eventId: Sentry.lastEventId()
+        type: getTypeFromError(e.reason)
       });
     };
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -75,6 +75,7 @@ export const ErrorBoundary = ({
           message: e.reason?.toString(),
         },
         type: getTypeFromError(e.reason),
+        eventId: Sentry.lastEventId()
       });
     };
 

--- a/src/components/ErrorModal.stories.tsx
+++ b/src/components/ErrorModal.stories.tsx
@@ -9,7 +9,7 @@ export const Default = () => {
 
   return <ErrorBoundary sentryDsn="https://0@o0.ingest.sentry.io/0">
     <ErrorModal
-      onModalClose={() => {}}
+      onModalClose={() => undefined}
       show={true}
     />
   </ErrorBoundary>;

--- a/src/components/ErrorModal.stories.tsx
+++ b/src/components/ErrorModal.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ErrorModal } from "./ErrorModal";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+export const Default = () => {
+  React.useEffect(() => {
+    Promise.reject('Test error for modal');
+  }, []);
+
+  return <ErrorBoundary sentryDsn="https://0@o0.ingest.sentry.io/0">
+    <ErrorModal
+      onModalClose={() => {}}
+      show={true}
+    />
+  </ErrorBoundary>;
+}

--- a/src/components/__snapshots__/Error.spec.tsx.snap
+++ b/src/components/__snapshots__/Error.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Error can override text 1`] = `
   </h3>
   Body text
   <div
-    className="sc-jqUVSM iYpgOz"
+    className="sc-jqUVSM iQgvmr"
   />
 </div>
 `;
@@ -36,7 +36,7 @@ exports[`Error matches snapshot 1`] = `
   </a>
   .
   <div
-    className="sc-jqUVSM iYpgOz"
+    className="sc-jqUVSM iQgvmr"
   />
 </div>
 `;

--- a/src/components/__snapshots__/Error.spec.tsx.snap
+++ b/src/components/__snapshots__/Error.spec.tsx.snap
@@ -13,6 +13,7 @@ exports[`Error can override text 1`] = `
   Body text
   <div
     className="sc-jqUVSM iQgvmr"
+    data-testid="event-id"
   />
 </div>
 `;
@@ -37,6 +38,7 @@ exports[`Error matches snapshot 1`] = `
   .
   <div
     className="sc-jqUVSM iQgvmr"
+    data-testid="event-id"
   />
 </div>
 `;

--- a/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`ErrorBoundary unhandled rejections are captured 1`] = `
   .
   <div
     className="sc-jqUVSM iQgvmr"
+    data-testid="event-id"
   >
     someuuid
   </div>
@@ -48,6 +49,7 @@ exports[`ErrorBoundary unhandled rejections does not crash on undefined reasons 
   .
   <div
     className="sc-jqUVSM iQgvmr"
+    data-testid="event-id"
   >
     someuuid
   </div>

--- a/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`ErrorBoundary unhandled rejections are captured 1`] = `
   <div
     className="sc-jqUVSM iYpgOz"
   >
-    1f869269d8fe4ee689d08100d763c001
+    someuuid
   </div>
 </div>
 `;
@@ -49,7 +49,7 @@ exports[`ErrorBoundary unhandled rejections does not crash on undefined reasons 
   <div
     className="sc-jqUVSM iYpgOz"
   >
-    1f869269d8fe4ee689d08100d763c001
+    someuuid
   </div>
 </div>
 `;

--- a/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
@@ -20,7 +20,9 @@ exports[`ErrorBoundary unhandled rejections are captured 1`] = `
   .
   <div
     className="sc-jqUVSM iYpgOz"
-  />
+  >
+    1f869269d8fe4ee689d08100d763c001
+  </div>
 </div>
 `;
 
@@ -46,6 +48,8 @@ exports[`ErrorBoundary unhandled rejections does not crash on undefined reasons 
   .
   <div
     className="sc-jqUVSM iYpgOz"
-  />
+  >
+    1f869269d8fe4ee689d08100d763c001
+  </div>
 </div>
 `;

--- a/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorBoundary.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`ErrorBoundary unhandled rejections are captured 1`] = `
   </a>
   .
   <div
-    className="sc-jqUVSM iYpgOz"
+    className="sc-jqUVSM iQgvmr"
   >
     someuuid
   </div>
@@ -47,7 +47,7 @@ exports[`ErrorBoundary unhandled rejections does not crash on undefined reasons 
   </a>
   .
   <div
-    className="sc-jqUVSM iYpgOz"
+    className="sc-jqUVSM iQgvmr"
   >
     someuuid
   </div>

--- a/src/components/__snapshots__/ErrorModal.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorModal.spec.tsx.snap
@@ -69,6 +69,7 @@ exports[`Modal matches snapshot 1`] = `
         .
         <div
           className="sc-crXcEl gaTpxy"
+          data-testid="event-id"
         />
       </div>
       <div

--- a/src/components/__snapshots__/ErrorModal.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorModal.spec.tsx.snap
@@ -68,7 +68,7 @@ exports[`Modal matches snapshot 1`] = `
         </a>
         .
         <div
-          className="sc-crXcEl fDJHVG"
+          className="sc-crXcEl gaTpxy"
         />
       </div>
       <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,6 +3010,29 @@
     magic-string "^0.25.0"
     string.prototype.matchall "^4.0.6"
 
+"@testing-library/dom@^8.0.0":
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.1.tgz#2e52a32e46fc88369eef7eef634ac2a192decd9f"
+  integrity sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@12":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -3019,6 +3042,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
+  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -3156,6 +3184,13 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react-dom@<18.0.0":
+  version "17.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
+  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
+  dependencies:
+    "@types/react" "^17"
 
 "@types/react-dom@^17.0.9":
   version "17.0.17"
@@ -3459,6 +3494,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
 
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
@@ -4353,6 +4395,30 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
+deep-equal@^2.0.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.2.tgz#9b2635da569a13ba8e1cc159c2f744071b115daa"
+  integrity sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.1"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.0"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-equal@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.1.tgz#c72ab22f3a7d3503a4ca87dde976fe9978816739"
@@ -4453,6 +4519,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-serializer@^1.0.1:
   version "1.4.1"
@@ -5375,7 +5446,7 @@ get-intrinsic@^1.1.3:
     has "^1.0.3"
     has-symbols "^1.0.3"
 
-get-intrinsic@^1.2.0:
+get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
   integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
@@ -6725,6 +6796,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -7570,6 +7646,15 @@ pretty-bytes@^5.4.1:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^28.0.0, pretty-format@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.1.tgz#f731530394e0f7fcd95aba6b43c50e02d86b95cb"
@@ -7743,7 +7828,7 @@ react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.2:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/2573

Right now errors in async code will display an error modal/screen but will not show an event id. Sentry watches for rejections and captures them internally, so the simplest way I could think of to render this is to look for `lastEventId`. This seems to work well from manual testing and hopefully will make it easier to track down reports from screenshots. I also increased the `id` font size so they are readable.