### PR TITLE
fix not removing the correct event handler on return

### DIFF
--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -150,13 +150,13 @@ export const SidebarNav = styled(
         }
       };
 
-      document.addEventListener("mousedown", handleOutsideEvent);
-      document.addEventListener("touchstart", handleOutsideEvent);
+      document.addEventListener("click", handleOutsideEvent);
+      document.addEventListener("touchend", handleOutsideEvent);
       document.addEventListener("keydown", handleKeyPress);
 
       return () => {
-        document.removeEventListener("mousedown", handleOutsideEvent);
-        document.removeEventListener("touchstart", handleOutsideEvent);
+        document.removeEventListener("click", handleOutsideEvent);
+        document.removeEventListener("touchend", handleOutsideEvent);
         document.removeEventListener("keydown", handleKeyPress);
       };
     }, [isMobile, navIsCollapsed, setNavIsCollapsed, sidebarNavRef]);

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -155,7 +155,7 @@ export const SidebarNav = styled(
       document.addEventListener("keydown", handleKeyPress);
 
       return () => {
-        document.removeEventListener("click", handleOutsideEvent);
+        document.removeEventListener("mousedown", handleOutsideEvent);
         document.removeEventListener("touchstart", handleOutsideEvent);
         document.removeEventListener("keydown", handleKeyPress);
       };


### PR DESCRIPTION
https://openstax.atlassian.net/browse/DISCO-29

Fixes not removing the correct handler on return, which was causing the menu to collapse on document click if initially loaded on mobile then expanded to desktop.