### PR TITLE
let dropdownmenu button and items wrap when the viewport is narrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -13,14 +13,15 @@ const StyledButton = styled(Button)<{ variant: ButtonVariant; width?: string }>`
   display: inline-flex;
   flex-direction: row;
   font-size: 1.6rem;
-  min-height: 2.5rem;
+  position: relative;
   justify-content: center;
   line-height: 2rem;
-  padding: 0 0.5rem;
+  min-height: 2.5rem;
+  padding: 0 1.5rem 0 0.5rem;
+  text-align: left;
   text-decoration: none;
   transition: all 0.2s ease-in-out;
   user-select: none;
-  text-align: left;
   ${(props) => props.width ? `width: ${props.width}` : null}
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -38,8 +39,10 @@ const StyledButton = styled(Button)<{ variant: ButtonVariant; width?: string }>`
     clip-path: polygon(0 0, 100% 100%, 100% 0);
     content: ' ';
     display: block;
+    position: absolute;
     height: 0.5rem;
-    margin: -0.25rem 0 0 0.5rem;
+    margin-top: -0.25rem;
+    right: 0.5rem;
     transform: rotate(135deg);
     width: 0.5rem;
   }

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -13,14 +13,14 @@ const StyledButton = styled(Button)<{ variant: ButtonVariant; width?: string }>`
   display: inline-flex;
   flex-direction: row;
   font-size: 1.6rem;
-  height: 2.5rem;
+  min-height: 2.5rem;
   justify-content: center;
   line-height: 2rem;
   padding: 0 0.5rem;
   text-decoration: none;
   transition: all 0.2s ease-in-out;
   user-select: none;
-  white-space: nowrap;
+  text-align: left;
   ${(props) => props.width ? `width: ${props.width}` : null}
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -55,7 +55,7 @@ const StyledMenu = styled(Menu)`
 
   [role="menuitem"] {
     font-size: 1.6rem;
-    height: 2.5rem;
+    min-height: 2.5rem;
     line-height: 2rem;
     padding: 0 0.5rem;
     cursor: pointer;

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -94,6 +94,7 @@ const ToggleButton = styled.button`
   border: 0.1rem solid #959595;
   border-right: 0;
   border-radius: 0.4rem 0 0 0.4rem;
+  z-index: 1;
 `;
 
 type FunctionRender = (_: {

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -50,7 +50,8 @@ const Nav = styled.nav`
     transition: opacity 300ms ease-in-out;
   }
 
-  &.mobile[aria-expanded="true"] ~ main::before {
+  &.mobile[aria-expanded="true"] ~ main::before,
+  &.mobile[aria-expanded="true"] ~ [data-backdrop-target]::before {
     background: rgba(0 0 0 / .7);
     opacity: 1;
     top: 0;

--- a/src/components/__snapshots__/DropdownMenu.spec.tsx.snap
+++ b/src/components/__snapshots__/DropdownMenu.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`DropdownMenu matches snapshots 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="sc-bczRLJ jfZUxx"
+    class="sc-bczRLJ hycKDG"
     data-rac=""
     id="react-aria-1"
     type="button"
@@ -20,7 +20,7 @@ exports[`DropdownMenu matches snapshots 2`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="sc-bczRLJ itqnA"
+    class="sc-bczRLJ dQDpcb"
     data-rac=""
     id="react-aria-3"
     type="button"

--- a/src/components/__snapshots__/DropdownMenu.spec.tsx.snap
+++ b/src/components/__snapshots__/DropdownMenu.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`DropdownMenu matches snapshots 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="sc-bczRLJ hycKDG"
+    class="sc-bczRLJ Ecumh"
     data-rac=""
     id="react-aria-1"
     type="button"
@@ -20,7 +20,7 @@ exports[`DropdownMenu matches snapshots 2`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="sc-bczRLJ dQDpcb"
+    class="sc-bczRLJ ilnBtE"
     data-rac=""
     id="react-aria-3"
     type="button"

--- a/src/components/__snapshots__/SidebarNav.spec.tsx.snap
+++ b/src/components/__snapshots__/SidebarNav.spec.tsx.snap
@@ -8,12 +8,12 @@ exports[`SidebarNav toggles nav collapse on button click 1`] = `
   />
   <nav
     aria-expanded="true"
-    class="sc-bczRLJ fLqWsF sc-jSMfEi"
+    class="sc-bczRLJ bjLBxB sc-jSMfEi"
     data-testid="sidebarnav"
   >
     <button
       aria-label="Collapse navigation"
-      class="sc-eCYdqJ eKnMif"
+      class="sc-eCYdqJ dqWmhQ"
       data-testid="sidebarnav-toggle"
     >
       <svg
@@ -50,12 +50,12 @@ exports[`SidebarNav toggles nav collapse on button click 2`] = `
   />
   <nav
     aria-expanded="false"
-    class="sc-bczRLJ fLqWsF sc-jSMfEi collapsed"
+    class="sc-bczRLJ bjLBxB sc-jSMfEi collapsed"
     data-testid="sidebarnav"
   >
     <button
       aria-label="Expand navigation"
-      class="sc-eCYdqJ eKnMif collapsed"
+      class="sc-eCYdqJ dqWmhQ collapsed"
       data-testid="sidebarnav-toggle"
     >
       <svg


### PR DESCRIPTION
https://openstax.atlassian.net/browse/DISCO-29

another small fix, should make this situation:

<img width="171" alt="image" src="https://github.com/user-attachments/assets/0f20368c-bfbd-4157-a2bb-ad50025a9394">

look more like this:

<img width="158" alt="image" src="https://github.com/user-attachments/assets/4cf9f918-e72b-4ee2-938b-0697cb36e1b3">

the absolute position changes are to prevent the triangle from skewing after it wraps:

<img width="247" alt="image" src="https://github.com/user-attachments/assets/ec621605-0ae0-4005-9b7a-6718c0be4b7e">
