### PR TITLE
Fix min width on tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.10.3",
+  "version": "1.10.5",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -15,7 +15,6 @@ const tooltipStyles = `
   /* fixes FF gap */
   transform: translate3d(0, 0, 0);
   position: absolute;
-  min-width: 24rem;
   z-index: 1000;
 
   &[data-placement=top] {
@@ -61,7 +60,7 @@ const tooltipStyles = `
 export const StyledTooltip = styled(AriaTooltip)`${tooltipStyles}`;
 
 const StyledCustomTooltip = styled.div`
-  ${tooltipStyles}  
+  ${tooltipStyles}
 `;
 
 export const StyledTrigger = styled(Button)`
@@ -78,7 +77,7 @@ type TooltipProps = {
   isOpen?: boolean;
 };
 
-export const Tooltip = ({children, placement, icon, ...props}: React.PropsWithChildren<TooltipProps>) => 
+export const Tooltip = ({children, placement, icon, ...props}: React.PropsWithChildren<TooltipProps>) =>
   <StyledTooltip {...props} placement={placement}>
   <OverlayArrow>
     <svg width={8} height={8} viewBox="0 0 8 8">

--- a/src/components/__snapshots__/Tooltip.spec.tsx.snap
+++ b/src/components/__snapshots__/Tooltip.spec.tsx.snap
@@ -76,7 +76,7 @@ Array [
     data-overlay-container={true}
   >
     <div
-      className="sc-bczRLJ dvhbKn"
+      className="sc-bczRLJ BxtqR"
       data-rac=""
       id="react-aria-1"
       onMouseEnter={[Function]}


### PR DESCRIPTION
Super low priority PR... Having a min-width on Tooltip was causing me issues with really narrow viewports, so it seems like removing it would be good? We can close this though if we'd rather target them on the consuming side or there are design concerns (not sure if we have Figma stuff for the tooltips...)