### PR TITLE
Add jira config marking all GitHub deployments development

### DIFF
--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -1,0 +1,7 @@
+deployments:
+  environmentMapping:
+    development:
+      - "*"
+    testing: []
+    staging: []
+    production: []


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-259

Based on the issue title, all github deployments should be mapped to `development`. Since this config should only be used for github deployments, it seems that it can just map everything to `development` (hence `"*"`). 

The config only works when it is on the main branch: "[...] you can add a file called .jira/config.yml to the main branch of your repository [...]"
