### PR TITLE
Use react-aria-components modal components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.10.8",
+  "version": "1.11.0",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",

--- a/src/components/CloseModalButton.tsx
+++ b/src/components/CloseModalButton.tsx
@@ -8,15 +8,17 @@ export const CloseModalButton = styled(({variant, ...props}) => (
     <Times aria-hidden='true' focusable='false' />
   </button>
 ))`
-  padding: 0.4rem;
+  padding: 0;
   cursor: pointer;
   margin-right: 0;
-  padding-right: 0;
   background: transparent;
   color: ${colors.palette.neutralMedium};
-  height: 2rem;
-  width: 2rem;
+  height: 2.4rem;
+  width: 2.4rem;
   border: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   :hover {
     color: ${colors.palette.neutralDark};

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,12 +1,13 @@
 import styled, { css } from "styled-components";
 import { colors, zIndex } from "../../src/theme";
-import { BodyPortal } from './BodyPortal';
 import { CloseModalButton } from "./CloseModalButton";
+import * as RAC from "react-aria-components";
+import React from "react";
 
 
 const modalPadding = 3;
 
-export const ModalCard = styled.div`
+export const ModalCard = styled(RAC.Dialog)`
   display: flex;
   flex-direction: column;
   margin: auto;
@@ -17,6 +18,7 @@ export const ModalCard = styled.div`
   color: ${colors.palette.neutralDarker};
   font-size: 1.6rem;
   line-height: 2.5rem;
+  outline: none;
 `;
 
 const Header = styled.header`
@@ -33,7 +35,7 @@ const Header = styled.header`
   `}
 `;
 
-const Heading = styled.h1`
+const Heading = styled(RAC.Heading)`
   display: flex;
   align-items: center;
   margin: 0;
@@ -52,7 +54,11 @@ export const ModalBody = styled.div`
   padding: ${modalPadding}rem;
 `;
 
-export const Mask = styled.div`
+export const Mask = styled(
+  (props: RAC.ModalOverlayProps & React.RefAttributes<HTMLDivElement>) => (
+    <RAC.ModalOverlay defaultOpen {...props}/>
+  )
+)`
   top: 0;
   left: 0;
   width: 100%;
@@ -60,19 +66,12 @@ export const Mask = styled.div`
   display: flex;
   position: fixed;
   background-color: rgba(0, 0, 0, 0.3);
-`;
-
-export const ModalWrapper = styled(BodyPortal)`
-  top: 0;
-  z-index: ${zIndex.modals};
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  position: fixed;
   justify-content: center;
   align-items: center;
+  z-index: ${zIndex.modals};
 `;
+
+export const ModalWrapper = RAC.Modal;
 
 const CardWrapper = styled.div`
   z-index: 1;
@@ -102,23 +101,30 @@ export const Modal = ({
   onModalClose,
   children,
   show,
-  variant
-}: React.PropsWithChildren<ModalPropTypes>) => {
+  variant,
+  ...props
+}: React.PropsWithChildren<ModalPropTypes> & RAC.ModalOverlayProps) => {
   if (!show) { return null; }
   return (
-    <ModalWrapper className={className} slot='modal'>
-      <CardWrapper>
-        <ModalCard>
-          <Header variant={variant}>
-            <Heading>
-              {heading}
-            </Heading>
-            <CloseModalButton onClick={onModalClose} variant={variant}/>
-          </Header>
-          {children}
-        </ModalCard>
-      </CardWrapper>
-      <Mask />
-    </ModalWrapper>
+    <Mask
+      className={className}
+      isDismissable
+      onOpenChange={(isOpen) => (!isOpen && onModalClose())}
+      {...props}
+    >
+      <ModalWrapper>
+        <CardWrapper>
+          <ModalCard>
+            <Header variant={variant}>
+              <Heading slot="title">
+                {heading}
+              </Heading>
+              <CloseModalButton onClick={onModalClose} variant={variant}/>
+            </Header>
+            {children}
+          </ModalCard>
+        </CardWrapper>
+      </ModalWrapper>
+    </Mask>
   );
 };

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import { CloseModalButton } from "./CloseModalButton";
 import { Mask, ModalWrapper } from "./Modal";
+import * as RAC from "react-aria-components";
+import React from "react";
 
 export const OverlayMask = styled(Mask)`
   background-color: rgba(0, 0, 0, 0.89);
@@ -10,16 +12,15 @@ export const OverlayCloseButton = styled(CloseModalButton)`
   height: 4rem;
   width: 4rem;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 2em;
+  top: 2em;
 `;
 
 export const OverlayWrapper = styled(ModalWrapper)`
   color: #fff;
-  padding: 4rem;
 `;
 
-export const OverlayBody = styled.div`
+export const OverlayBody = styled(RAC.Dialog)`
   position: relative;
   flex-grow: 1;
   height: 100%;
@@ -28,26 +29,34 @@ export const OverlayBody = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  outline: none;
 `;
 
 export const Overlay = ({
   className,
   onClose,
   children,
-  show
+  show,
+  ...props
 }: React.PropsWithChildren<{
   onClose: () => void;
   className?: string;
   show?: boolean;
-}>) => {
+}> & RAC.ModalOverlayProps) => {
   if (!show) { return null; }
   return (
-    <OverlayWrapper className={className} slot='overlay'>
-      <OverlayBody>
+    <OverlayMask
+      className={className}
+      isDismissable
+      onOpenChange={(isOpen) => (!isOpen && onClose())}
+      {...props}
+    >
+      <OverlayWrapper defaultOpen={true}>
         <OverlayCloseButton onClick={onClose} variant={'inverted-circle'} />
-        { children }
+        <OverlayBody>
+          { children }
         </OverlayBody>
-      <OverlayMask />
-    </OverlayWrapper >
+      </OverlayWrapper>
+    </OverlayMask>
   );
 };

--- a/src/components/__snapshots__/CloseModalButton.spec.tsx.snap
+++ b/src/components/__snapshots__/CloseModalButton.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CloseModalButton should render with default styles 1`] = `
 <button
   aria-label="Close"
-  className="sc-bczRLJ hfFFie"
+  className="sc-bczRLJ esYXKz"
   type="button"
 >
   <svg
@@ -40,7 +40,7 @@ exports[`CloseModalButton should render with default styles 1`] = `
 exports[`CloseModalButton should render with error variant styles 1`] = `
 <button
   aria-label="Close"
-  className="sc-bczRLJ sZVOj"
+  className="sc-bczRLJ elXiRy"
   type="button"
 >
   <svg
@@ -77,7 +77,7 @@ exports[`CloseModalButton should render with error variant styles 1`] = `
 exports[`CloseModalButton should render with inverted-circle variant styles 1`] = `
 <button
   aria-label="Close"
-  className="sc-bczRLJ eblJCO"
+  className="sc-bczRLJ jrboUT"
   type="button"
 >
   <svg

--- a/src/components/__snapshots__/Error.spec.tsx.snap
+++ b/src/components/__snapshots__/Error.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Error can override text 1`] = `
   </h3>
   Body text
   <div
-    className="sc-jqUVSM iQgvmr"
+    className="sc-papXJ dnjAXW"
     data-testid="event-id"
   />
 </div>
@@ -37,7 +37,7 @@ exports[`Error matches snapshot 1`] = `
   </a>
   .
   <div
-    className="sc-jqUVSM iQgvmr"
+    className="sc-papXJ dnjAXW"
     data-testid="event-id"
   />
 </div>

--- a/src/components/__snapshots__/ErrorModal.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorModal.spec.tsx.snap
@@ -3,196 +3,254 @@
 exports[`Modal matches snapshot 1`] = `
 <body>
   <main
+    aria-hidden="true"
     id="root"
   />
+  <span
+    aria-hidden="true"
+    data-focus-scope-start="true"
+    hidden=""
+  />
   <div
-    class="sc-jqUVSM keToMA"
-    data-portal-slot="modal"
+    class="sc-papXJ dSNZGe"
+    data-rac=""
+    style="--visual-viewport-height: 768px;"
   >
     <div
-      class="sc-kDDrLX kcRDJd"
+      class="react-aria-Modal"
+      data-rac=""
     >
       <div
-        class="sc-eCYdqJ kjjlDI"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
-        <header
-          class="sc-jSMfEi klYGKb"
+        <button
+          aria-label="Dismiss"
+          id="react-aria-1"
+          style="width: 1px; height: 1px;"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="sc-jqUVSM kHnGYC"
+      >
+        <section
+          aria-labelledby="react-aria-2"
+          class="sc-eCYdqJ iasutB"
+          role="dialog"
+          tabindex="-1"
         >
-          <h1
-            class="sc-gKXOVf czyrNV"
+          <header
+            class="sc-jSMfEi klYGKb"
           >
-            Error
-          </h1>
-          <button
-            aria-label="Close"
-            class="sc-hKMtZM hEOiqB"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="15px"
-              version="1.1"
-              viewBox="0 0 15 15"
-              width="15px"
+            <h2
+              class="sc-gKXOVf czyrNV"
+              id="react-aria-2"
+              slot="title"
             >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-                stroke="none"
-                stroke-width="1"
+              Error
+            </h2>
+            <button
+              aria-label="Close"
+              class="sc-hKMtZM jBFomg"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="15px"
+                version="1.1"
+                viewBox="0 0 15 15"
+                width="15px"
               >
                 <g
-                  fill="currentColor"
-                  transform="translate(-302.000000, -18.000000)"
+                  fill="none"
+                  fill-rule="evenodd"
+                  stroke="none"
+                  stroke-width="1"
                 >
                   <g
-                    transform="translate(302.000000, 18.000000)"
+                    fill="currentColor"
+                    transform="translate(-302.000000, -18.000000)"
                   >
-                    <path
-                      d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
-                    />
+                    <g
+                      transform="translate(302.000000, 18.000000)"
+                    >
+                      <path
+                        d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
+                      />
+                    </g>
                   </g>
                 </g>
-              </g>
-            </svg>
-          </button>
-        </header>
-        <div
-          class="sc-ftvSup dDFSJu"
-          data-testid="error"
-        >
-          <h3
-            class="sc-iBkjds jzXZzg"
-          >
-            Uh-oh, there's been a glitch
-          </h3>
-          We're not quite sure what went wrong. Restart your browser. If this doesn't solve the problem, visit our 
-          <a
-            href="https://openstax.secure.force.com/help"
-            target="_blank"
-          >
-            Support Center
-          </a>
-          .
+              </svg>
+            </button>
+          </header>
           <div
-            class="sc-crXcEl gaTpxy"
-            data-testid="event-id"
-          />
-        </div>
-        <div
-          class="sc-iqcoie cqUGeK"
-        >
-          <button
-            class="sc-bczRLJ jBPkZO"
+            class="sc-ftvSup dDFSJu"
+            data-testid="error"
           >
-            OK
-          </button>
-        </div>
+            <h3
+              class="sc-iBkjds jzXZzg"
+            >
+              Uh-oh, there's been a glitch
+            </h3>
+            We're not quite sure what went wrong. Restart your browser. If this doesn't solve the problem, visit our 
+            <a
+              href="https://openstax.secure.force.com/help"
+              target="_blank"
+            >
+              Support Center
+            </a>
+            .
+            <div
+              class="sc-iqcoie hdouAN"
+              data-testid="event-id"
+            />
+          </div>
+          <div
+            class="sc-kDDrLX elkCOb"
+          >
+            <button
+              class="sc-bczRLJ jBPkZO"
+            >
+              OK
+            </button>
+          </div>
+        </section>
       </div>
     </div>
-    <div
-      class="sc-papXJ dLOChU"
-    />
   </div>
+  <span
+    aria-hidden="true"
+    data-focus-scope-end="true"
+    hidden=""
+  />
 </body>
 `;
 
 exports[`Modal matches snapshot when heading and children are set 1`] = `
 <body>
   <main
+    aria-hidden="true"
     id="root"
   />
+  <span
+    aria-hidden="true"
+    data-focus-scope-start="true"
+    hidden=""
+  />
   <div
-    class="sc-jqUVSM keToMA"
-    data-portal-slot="modal"
+    class="sc-papXJ dSNZGe"
+    data-rac=""
+    style="--visual-viewport-height: 768px;"
   >
     <div
-      class="sc-kDDrLX kcRDJd"
+      class="react-aria-Modal"
+      data-rac=""
     >
       <div
-        class="sc-eCYdqJ kjjlDI"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
-        <header
-          class="sc-jSMfEi klYGKb"
+        <button
+          aria-label="Dismiss"
+          id="react-aria-3"
+          style="width: 1px; height: 1px;"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="sc-jqUVSM kHnGYC"
+      >
+        <section
+          aria-labelledby="react-aria-4"
+          class="sc-eCYdqJ iasutB"
+          role="dialog"
+          tabindex="-1"
         >
-          <h1
-            class="sc-gKXOVf czyrNV"
+          <header
+            class="sc-jSMfEi klYGKb"
           >
-            Error
-          </h1>
-          <button
-            aria-label="Close"
-            class="sc-hKMtZM hEOiqB"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="15px"
-              version="1.1"
-              viewBox="0 0 15 15"
-              width="15px"
+            <h2
+              class="sc-gKXOVf czyrNV"
+              id="react-aria-4"
+              slot="title"
             >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-                stroke="none"
-                stroke-width="1"
+              Error
+            </h2>
+            <button
+              aria-label="Close"
+              class="sc-hKMtZM jBFomg"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="15px"
+                version="1.1"
+                viewBox="0 0 15 15"
+                width="15px"
               >
                 <g
-                  fill="currentColor"
-                  transform="translate(-302.000000, -18.000000)"
+                  fill="none"
+                  fill-rule="evenodd"
+                  stroke="none"
+                  stroke-width="1"
                 >
                   <g
-                    transform="translate(302.000000, 18.000000)"
+                    fill="currentColor"
+                    transform="translate(-302.000000, -18.000000)"
                   >
-                    <path
-                      d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
-                    />
+                    <g
+                      transform="translate(302.000000, 18.000000)"
+                    >
+                      <path
+                        d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
+                      />
+                    </g>
                   </g>
                 </g>
-              </g>
-            </svg>
-          </button>
-        </header>
-        <div
-          class="sc-ftvSup dDFSJu"
-          data-testid="error"
-        >
-          <h3
-            class="sc-iBkjds jzXZzg"
-          >
-            Scores not sent
-          </h3>
-          There was an issue syncing your scores. Please try again in a few minutes. If the issue persists, visit our
-          <a
-            href="https://openstax.secure.force.com/help"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Support Center
-          </a>
-          .
+              </svg>
+            </button>
+          </header>
           <div
-            class="sc-crXcEl gaTpxy"
-            data-testid="event-id"
-          />
-        </div>
-        <div
-          class="sc-iqcoie cqUGeK"
-        >
-          <button
-            class="sc-bczRLJ jBPkZO"
+            class="sc-ftvSup dDFSJu"
+            data-testid="error"
           >
-            OK
-          </button>
-        </div>
+            <h3
+              class="sc-iBkjds jzXZzg"
+            >
+              Scores not sent
+            </h3>
+            There was an issue syncing your scores. Please try again in a few minutes. If the issue persists, visit our
+            <a
+              href="https://openstax.secure.force.com/help"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Support Center
+            </a>
+            .
+            <div
+              class="sc-iqcoie hdouAN"
+              data-testid="event-id"
+            />
+          </div>
+          <div
+            class="sc-kDDrLX elkCOb"
+          >
+            <button
+              class="sc-bczRLJ jBPkZO"
+            >
+              OK
+            </button>
+          </div>
+        </section>
       </div>
     </div>
-    <div
-      class="sc-papXJ dLOChU"
-    />
   </div>
+  <span
+    aria-hidden="true"
+    data-focus-scope-end="true"
+    hidden=""
+  />
 </body>
 `;

--- a/src/components/__snapshots__/Modal.spec.tsx.snap
+++ b/src/components/__snapshots__/Modal.spec.tsx.snap
@@ -11,71 +11,100 @@ exports[`Modal hides 1`] = `
 exports[`Modal matches snapshot 1`] = `
 <body>
   <main
+    aria-hidden="true"
     id="root"
   />
+  <span
+    aria-hidden="true"
+    data-focus-scope-start="true"
+    hidden=""
+  />
   <div
-    class="sc-iBkjds cXUNFT"
-    data-portal-slot="modal"
+    class="sc-gKXOVf fbFzda"
+    data-rac=""
+    style="--visual-viewport-height: 768px;"
   >
     <div
-      class="sc-ftvSup YygFK"
+      class="react-aria-Modal"
+      data-rac=""
     >
       <div
-        class="sc-gsnTZi liuLzN"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
-        <header
-          class="sc-dkzDqf hlAehe"
+        <button
+          aria-label="Dismiss"
+          id="react-aria-1"
+          style="width: 1px; height: 1px;"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="sc-iBkjds mgorR"
+      >
+        <section
+          aria-labelledby="react-aria-2"
+          class="sc-gsnTZi gQTek"
+          role="dialog"
+          tabindex="-1"
         >
-          <h1
-            class="sc-hKMtZM gKFAwv"
+          <header
+            class="sc-dkzDqf hlAehe"
           >
-            Heading
-          </h1>
-          <button
-            aria-label="Close"
-            class="sc-bczRLJ hfFFie"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="15px"
-              version="1.1"
-              viewBox="0 0 15 15"
-              width="15px"
+            <h2
+              class="sc-hKMtZM gKFAwv"
+              id="react-aria-2"
+              slot="title"
             >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-                stroke="none"
-                stroke-width="1"
+              Heading
+            </h2>
+            <button
+              aria-label="Close"
+              class="sc-bczRLJ esYXKz"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="15px"
+                version="1.1"
+                viewBox="0 0 15 15"
+                width="15px"
               >
                 <g
-                  fill="currentColor"
-                  transform="translate(-302.000000, -18.000000)"
+                  fill="none"
+                  fill-rule="evenodd"
+                  stroke="none"
+                  stroke-width="1"
                 >
                   <g
-                    transform="translate(302.000000, 18.000000)"
+                    fill="currentColor"
+                    transform="translate(-302.000000, -18.000000)"
                   >
-                    <path
-                      d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
-                    />
+                    <g
+                      transform="translate(302.000000, 18.000000)"
+                    >
+                      <path
+                        d="M7.5,5.41522791 L12.0331524,0.579865364 C12.3077536,0.286957429 12.7165503,0.24816296 12.946282,0.493210121 L13.9861449,1.60239723 C14.2158766,1.84744439 14.1795068,2.28349422 13.9049056,2.57640216 L9.37175324,7.41176471 L13.9049056,12.2471273 C14.1795068,12.5400352 14.2158766,12.976085 13.9861449,13.2211322 L12.946282,14.3303193 C12.7165503,14.5753665 12.3077536,14.536572 12.0331524,14.243664 L7.5,9.4083015 L2.96684761,14.243664 C2.69224642,14.536572 2.2834497,14.5753665 2.05371799,14.3303193 L1.01385508,13.2211322 C0.784123363,12.976085 0.820493178,12.5400352 1.09509437,12.2471273 L5.62824676,7.41176471 L1.09509437,2.57640216 C0.820493178,2.28349422 0.784123363,1.84744439 1.01385508,1.60239723 L2.05371799,0.493210121 C2.2834497,0.24816296 2.69224642,0.286957429 2.96684761,0.579865364 L7.5,5.41522791 Z"
+                      />
+                    </g>
                   </g>
                 </g>
-              </g>
-            </svg>
-          </button>
-        </header>
-        <div
-          class="sc-jSMfEi cWLUhq"
-        >
-          Modal Body
-        </div>
+              </svg>
+            </button>
+          </header>
+          <div
+            class="sc-jSMfEi cWLUhq"
+          >
+            Modal Body
+          </div>
+        </section>
       </div>
     </div>
-    <div
-      class="sc-gKXOVf etxkPo"
-    />
   </div>
+  <span
+    aria-hidden="true"
+    data-focus-scope-end="true"
+    hidden=""
+  />
 </body>
 `;

--- a/src/components/__snapshots__/Overlay.spec.tsx.snap
+++ b/src/components/__snapshots__/Overlay.spec.tsx.snap
@@ -11,18 +11,36 @@ exports[`Overlay hides 1`] = `
 exports[`Overlay matches snapshot 1`] = `
 <body>
   <main
+    aria-hidden="true"
     id="root"
   />
+  <span
+    aria-hidden="true"
+    data-focus-scope-start="true"
+    hidden=""
+  />
   <div
-    class="sc-iBkjds sc-iqcoie cXUNFT dHqhuo"
-    data-portal-slot="overlay"
+    class="sc-gKXOVf sc-papXJ fbFzda iQrgxx"
+    data-rac=""
+    style="--visual-viewport-height: 768px;"
   >
     <div
-      class="sc-crXcEl fbCIbU"
+      class="sc-kDDrLX cNjBYx"
+      data-rac=""
     >
+      <div
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <button
+          aria-label="Dismiss"
+          id="react-aria-1"
+          style="width: 1px; height: 1px;"
+          tabindex="-1"
+        />
+      </div>
       <button
         aria-label="Close"
-        class="sc-bczRLJ sc-kDDrLX eblJCO fWCYnN"
+        class="sc-bczRLJ sc-jqUVSM jrboUT fvgMNu"
         type="button"
       >
         <svg
@@ -54,11 +72,19 @@ exports[`Overlay matches snapshot 1`] = `
           </g>
         </svg>
       </button>
-      Inner content
+      <section
+        class="sc-iqcoie elTIlC"
+        role="dialog"
+        tabindex="-1"
+      >
+        Inner content
+      </section>
     </div>
-    <div
-      class="sc-gKXOVf sc-jqUVSM etxkPo hjYSJA"
-    />
   </div>
+  <span
+    aria-hidden="true"
+    data-focus-scope-end="true"
+    hidden=""
+  />
 </body>
 `;


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-482

Use react-aria-components [Modal](https://react-spectrum.adobe.com/react-aria/Modal.html)  and friends for modals that capture focus and can be dismissed with `Escape` or by clicking behind them.

- With this change, the modals are added to a body portal maintained by react-aria-components. It is possible to use the ui-components body portal, but it breaks some functionality in the aria components.
- `Mask`/`ModalOverlay` becomes the parent element: will require some changes to styling. So far I have only found [RecoveryCredentialsOverlay](https://github.com/openstax/assignments/blob/14ea5b7d500eb8f5edd7d9e91dc2ec775cb4d0ca/packages/frontend/src/student/components/RecoveryCredentials/RecoveryCredentialsOverlay.tsx#L144).
- I needed to change the style of `Mask`/`ModalWrapper` to support dismissing the dialog by clicking off of it (because you need to be able to click behind the dialog content, which was previously occupying the entire space of `Mask`). This lead to some changes in `OverlayCloseButton` too.

Here's a screenshot of the `RecoveryCredentialsOverlay` with some styles moved around to accommodate the aforementioned changes (also available on [this branch](https://github.com/openstax/assignments/tree/core-482-overlay-change)):

<img width="1433" alt="Screenshot 2024-12-02 at 1 22 28 PM" src="https://github.com/user-attachments/assets/a29dd1eb-b83d-4602-821f-3ab001516129">



And a screenshot of the same overlay as it appeared before:
<img width="1433" alt="Screenshot 2024-12-02 at 11 00 45 AM" src="https://github.com/user-attachments/assets/d55fab04-d3bc-430a-8319-afce6cbde33e">

