### PR TITLE
Set min-width to 0 on NavBar BarWrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,6 +14,7 @@ const BarWrapper = styled(BodyPortal)`
   ${theme.breakpoints.desktop(css`
     padding: 0 ${theme.padding.navbar.mobile}rem;
   `)}
+  min-width: 0;
 `;
 
 const StyledNavBar = styled.div<{

--- a/src/components/__snapshots__/NavBar.spec.tsx.snap
+++ b/src/components/__snapshots__/NavBar.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`NavBar matches snapshot 1`] = `
     id="root"
   />
   <nav
-    class="sc-gsnTZi dMcFZD"
+    class="sc-gsnTZi cnSXvF"
     data-portal-slot="nav"
   >
     <div
@@ -24,7 +24,7 @@ exports[`NavBar sets the maxWidth 1`] = `
     id="root"
   />
   <nav
-    class="sc-gsnTZi dMcFZD"
+    class="sc-gsnTZi cnSXvF"
     data-portal-slot="nav"
   >
     <div
@@ -42,7 +42,7 @@ exports[`NavBar with a logo customizes the alt text 1`] = `
     id="root"
   />
   <nav
-    class="sc-gsnTZi dMcFZD"
+    class="sc-gsnTZi cnSXvF"
     data-portal-slot="nav"
   >
     <div
@@ -100,7 +100,7 @@ exports[`NavBar with a logo links the logo 1`] = `
     id="root"
   />
   <nav
-    class="sc-gsnTZi dMcFZD"
+    class="sc-gsnTZi cnSXvF"
     data-portal-slot="nav"
   >
     <div
@@ -162,7 +162,7 @@ exports[`NavBar with a logo matches snapshot 1`] = `
     id="root"
   />
   <nav
-    class="sc-gsnTZi dMcFZD"
+    class="sc-gsnTZi cnSXvF"
     data-portal-slot="nav"
   >
     <div


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-421

Add `min-width: 0` to `BarWrapper` so that it scales down. Without this, it was scaling down to the combined minimum size of its descendants and then stopped.

## Before

<img width="338" alt="Screenshot 2024-12-09 at 12 10 21 PM" src="https://github.com/user-attachments/assets/56aad664-318f-4d0e-a26d-c818afecff22">

## After

<img width="338" alt="Screenshot 2024-12-09 at 12 12 40 PM" src="https://github.com/user-attachments/assets/0ece94ea-99a6-4988-847d-2e72cdf52000">
