### PR TITLE
[CORE-642] update HelpMenu to use component-based approach instead of hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,99 @@
 
 General UI components for OpenStax projects.
 
+## Installation
+Add to your project using GitHub tags:
+
+```json
+"dependencies": {
+  "@openstax/ui-components": "https://github.com/openstax/ui-components#1.15.0"
+}
+```
+Use a version that matches your project's requirements.
+
+## Versioning & Release Process
+
+### Git Tags
+We use Git tags instead of npm publishing:
+- Standard: `1.15.0`, `1.15.1`
+- Pre-release: `1.15.3-pre1`
+- Feature-specific: `sentry-logger-03212025`
+
+### Creating a Release
+You'll need to include the built `dist` directory in your tag:
+
+
+```bash
+# one-liner grab-and-go
+# 1. Create a temporary branch and build distribution files
+# This removes any existing 'dist' branch, creates a new one, builds the files,
+# then force-adds them to git (since dist/ is gitignored)
+# The `dist` directory is normally gitignored but must be included in release tags.
+# This is why the release process uses a temporary branch with force-adding the built files.
+(git branch -D dist || true) && git checkout -b dist && yarn dist && git add -f dist && git commit -m 'dist'
+
+# 2. Tag the commit with your version
+# Replace [version] with your actual version number (e.g., 1.15.0, 2.0.0-beta1, 20250410-component-for-x)
+git tag [version]
+
+# 3. Push the tag to GitHub
+# You can push all tags with `git push --tags`
+# **OR** push a specific tag with:
+git push origin [version]
+```
+
+This temporary branch is just for tagging — no need to merge it. After pushing the tag, you can return to your original branch.
+
+## Build Output
+
+The `dist` directory (included only in tags) contains:
+- CommonJS: `index.js`
+- ES Modules: `index.module.js`
+- Modern ESM: `index.modern.mjs` 
+- UMD: `index.umd.js`
+- TypeScript types: `index.d.ts`
+
+## CI/CD Workflows
+
+### Checks Workflow
+Runs on PRs and main branch, handling:
+- Jira ticket verification
+- Linting and tests
+
+## Usage in Projects
+
+```typescript
+// Import all components
+import * as UI from '@openstax/ui-components';
+
+// Or just what you need
+import { Button, Modal } from '@openstax/ui-components';
+```
+
 ## Development
 
-- `yarn dev` watch files and recompile them when they change
-- `yarn test` run tests and get coverage results
-- `yarn lint` run eslint
-- `yarn ladle serve` run Ladle server at http://localhost:61000 to view component stories
+```bash
+yarn dev         # Watch mode
+yarn ladle serve # Component demos at localhost:61000
+yarn test        # Run tests
+yarn lint        # Check code rules
+yarn dist        # Build distribution files
+```
+
+## Testing Across Projects
+
+To test changes before tagging:
+
+1. Push your branch
+2. Update the consuming project temporarily:
+   ```json
+   "@openstax/ui-components": "https://github.com/openstax/ui-components#your-branch"
+   ```
+3. After testing, create and push a proper version tag
+
+## Best Practices
+
+- Update `CHANGELOG.md` with significant changes
+- Coordinate breaking changes with dependent projects
+- Include tests and Ladle stories for new components
+- Export all components from `src/index.ts`

--- a/README.md
+++ b/README.md
@@ -21,25 +21,64 @@ We use Git tags instead of npm publishing:
 - Feature-specific: `sentry-logger-03212025`
 
 ### Creating a Release
-You'll need to include the built `dist` directory in your tag:
+There are three ways to create a release, choose the one that best fits your needs:
+- **Publish Script (Recommended)**: The fastest and safest way to create standard releases. Use this for most releases.
+- **Manual Release Process**: Step-by-step process that mirrors what the publish script does. Useful when you need more control over the release process.
+- **Experimental/Pre-release**: Quick process for creating test versions or pre-releases. Ideal for feature testing or alpha/beta releases.
 
+#### Using the Publish Script (Recommended)
+The simplest way to create a release:
+
+1. Update the version in `package.json`
+2. Ensure your working directory is clean (commit or stash any changes)
+3. Run `./scripts/publish.bash`
+
+This script automates the release process, handling the build and tag creation steps for you.
+
+#### Manual Release Process
+Alternatively, you can create a release manually following these steps:
+
+1. Update the version in `package.json`
+2. Ensure your working directory is clean (commit or stash any changes)
+3. Run `yarn --check-files` to verify dependencies
+4. Create a release branch:
+   ```bash
+   release_branch="release-$(date +%Y-%m-%d_%H-%M-%S)"
+   git checkout -b "$release_branch"
+   ```
+5. Build the distribution files:
+   ```bash
+   yarn build:clean
+   git add -f dist/
+   git commit -m "adding dist files"
+   ```
+6. Create and push the tag:
+   ```bash
+   version=$(node -p "require('./package.json').version")
+   git tag "$version"
+   git push origin tag "$version"
+   ```
+7. Return to your original branch:
+   ```bash
+   git checkout -
+   ```
+
+#### Creating Experimental/Pre-release Tags
+For testing experimental features or creating pre-release versions, you can use this simplified process:
 
 ```bash
 # one-liner grab-and-go
 # 1. Create a temporary branch and build distribution files
 # This removes any existing 'dist' branch, creates a new one, builds the files,
 # then force-adds them to git (since dist/ is gitignored)
-# The `dist` directory is normally gitignored but must be included in release tags.
-# This is why the release process uses a temporary branch with force-adding the built files.
 (git branch -D dist || true) && git checkout -b dist && yarn dist && git add -f dist && git commit -m 'dist'
 
 # 2. Tag the commit with your version
-# Replace [version] with your actual version number (e.g., 1.15.0, 2.0.0-beta1, 20250410-component-for-x)
+# Use appropriate version format for experimental/pre-release tags
+# Examples: 2.0.0-beta1, 2.0.0-alpha.3, feature-test-20240415
 git tag [version]
 
 # 3. Push the tag to GitHub
-# You can push all tags with `git push --tags`
-# **OR** push a specific tag with:
 git push origin [version]
 ```
 

--- a/src/components/HelpMenu.spec.tsx
+++ b/src/components/HelpMenu.spec.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
 import { BodyPortalSlotsContext } from './BodyPortalSlotsContext';
-import { useHelpMenu } from './HelpMenu';
+import { HelpMenu, HelpMenuItem } from './HelpMenu';
 import { NavBar } from './NavBar';
 
-describe('useHelpMenu', () => {
+describe('HelpMenu', () => {
   let root: HTMLElement;
 
   beforeEach(() => {
@@ -13,18 +13,17 @@ describe('useHelpMenu', () => {
   });
 
   it('matches snapshot', () => {
-    const NavBarWithHelpMenu = () => {
-      const [HelpMenu, ContactFormIframe] = useHelpMenu(
-        [{ label: 'Test Callback', callback: () => window.alert('Ran HelpMenu callback function') }]
-      );
-
-      return <BodyPortalSlotsContext.Provider value={['nav', 'root']}>
-        <NavBar logo><HelpMenu contactFormParams={[{key: 'userId', value: 'test'}]} /></NavBar>
-        <ContactFormIframe />
-      </BodyPortalSlotsContext.Provider>;
-    };
-
-    render(<NavBarWithHelpMenu />);
+    render(
+      <BodyPortalSlotsContext.Provider value={['nav', 'root']}>
+        <NavBar logo>
+          <HelpMenu contactFormParams={[{key: 'userId', value: 'test'}]}>
+            <HelpMenuItem onAction={() => window.alert('Ran HelpMenu callback function')}>
+              Test Callback
+            </HelpMenuItem>
+          </HelpMenu>
+        </NavBar>
+      </BodyPortalSlotsContext.Provider>
+    );
 
     expect(document.body).toMatchSnapshot();
   });

--- a/src/components/HelpMenu.stories.tsx
+++ b/src/components/HelpMenu.stories.tsx
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 import { BodyPortalSlotsContext } from './BodyPortalSlotsContext';
-import { useHelpMenu } from './HelpMenu';
+import { HelpMenu, HelpMenuItem } from './HelpMenu';
 import { NavBar } from './NavBar';
 
 const BodyPortalGlobalStyle = createGlobalStyle`
@@ -12,13 +12,16 @@ const BodyPortalGlobalStyle = createGlobalStyle`
 `;
 
 export const Default = () => {
-  const [HelpMenu, ContactFormIframe] = useHelpMenu(
-    [{ label: 'Test Callback', callback: () => window.alert('Ran HelpMenu callback function') }]
+  return (
+    <BodyPortalSlotsContext.Provider value={['nav', 'root']}>
+      <BodyPortalGlobalStyle />
+      <NavBar logo>
+        <HelpMenu contactFormParams={[{key: 'userId', value: 'test'}]}>
+          <HelpMenuItem onAction={() => window.alert('Ran HelpMenu callback function')}>
+            Test Callback
+          </HelpMenuItem>
+        </HelpMenu>
+      </NavBar>
+    </BodyPortalSlotsContext.Provider>
   );
-
-  return <BodyPortalSlotsContext.Provider value={['nav', 'root']}>
-    <BodyPortalGlobalStyle />
-    <NavBar logo><HelpMenu contactFormParams={[{key: 'userId', value: 'test'}]} /></NavBar>
-    <ContactFormIframe />
-  </BodyPortalSlotsContext.Provider>;
 };

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -2,28 +2,28 @@ import React from 'react';
 import { NavBarMenuButton, NavBarMenuItem } from './NavBarMenuButtons';
 import { colors } from '../theme';
 import styled from 'styled-components';
+import { BodyPortal } from './BodyPortal';
 
-export const styledMenu = {
-  Button: styled(NavBarMenuButton)`
-    color: ${colors.palette.gray};
-    font-size: 1.4rem;
-  `,
-  Item: styled(NavBarMenuItem)`
+export const HelpMenuButton = styled(NavBarMenuButton)`
+  color: ${colors.palette.gray};
+  font-size: 1.4rem;
+`;
+
+export const HelpMenuItem = styled(NavBarMenuItem)`
+  color: ${colors.palette.neutralDarker};
+  text-decoration: none;
+
+  :focus-visible {
+    outline: 0;
+    background: ${colors.palette.neutralLighter};
+  }
+  :hover {
     color: ${colors.palette.neutralDarker};
     text-decoration: none;
+  }
+`;
 
-    :focus-visible {
-      outline: 0;
-      background: ${colors.palette.neutralLighter};
-    }
-    :hover {
-      color: ${colors.palette.neutralDarker};
-      text-decoration: none;
-    }
-  `,
-};
-
-const IframeWrapper = styled.div`
+const IframeWrapper = styled(BodyPortal)`
   background-color: ${colors.palette.neutralBright};
   position: absolute;
   width: 100%;
@@ -70,106 +70,80 @@ const StyledPutAway = styled(PutAway)`
     height: 3rem;
     background-color: ${colors.palette.white};
     border: 1px solid ${colors.palette.pale};
-    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     width: 9rem;
     border-radius: 0.5rem;
   }
 `;
 
-const newTabIcon = <svg
-  role='img'
-  width='12'
-  height='11'
-  viewBox='0 0 12 11'
-  fill='none'
-  xmlns='http://www.w3.org/2000/svg'
+/**
+ * SVG icon representing a "new tab" indicator
+ * Used to visually indicate when a link or action will open in a new tab/window
+ * 
+ * Dimensions: 12x11 pixels
+ * Uses theme color: colors.palette.neutralThin
+ */
+export const NewTabIcon = () => (
+  <svg
+    role='img'
+    width='12'
+    height='11'
+    viewBox='0 0 12 11'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
   >
-  <title>new tab</title>
-  <path
-    d='M12 0.832214V3.49855C12 3.94565 11.4592 4.1648 11.1464 3.85211L10.4025 3.10817L5.32915 8.18157C5.13387 8.37684 4.81731 8.37684 4.62204 8.18157L4.15065 7.71017C3.95538 7.5149 3.95538 7.19832 4.15065 7.00307L9.22408 1.92963L8.48027 1.18578C8.16629 0.871798 8.38867 0.332214 8.83383 0.332214H11.5C11.7761 0.332214 12 0.556069 12 0.832214ZM8.47977 5.97376L8.14644 6.30709C8.10001 6.35352 8.06318 6.40864 8.03805 6.46931C8.01293 6.52997 8 6.59499 8 6.66065V9.66555H1.33333V2.99888H6.83333C6.96594 2.99887 7.0931 2.9462 7.18688 2.85244L7.52021 2.51911C7.83519 2.20411 7.6121 1.66555 7.16667 1.66555H1C0.447708 1.66555 0 2.11326 0 2.66555V9.99888C0 10.5512 0.447708 10.9989 1 10.9989H8.33333C8.88562 10.9989 9.33333 10.5512 9.33333 9.99888V6.3273C9.33333 5.88184 8.79475 5.65876 8.47977 5.97376Z'
-    fill='#6F6F6F'
-  />
-</svg>;
+    <title>new tab</title>
+    <path
+      d='M12 0.832214V3.49855C12 3.94565 11.4592 4.1648 11.1464 3.85211L10.4025 3.10817L5.32915 8.18157C5.13387 8.37684 4.81731 8.37684 4.62204 8.18157L4.15065 7.71017C3.95538 7.5149 3.95538 7.19832 4.15065 7.00307L9.22408 1.92963L8.48027 1.18578C8.16629 0.871798 8.38867 0.332214 8.83383 0.332214H11.5C11.7761 0.332214 12 0.556069 12 0.832214ZM8.47977 5.97376L8.14644 6.30709C8.10001 6.35352 8.06318 6.40864 8.03805 6.46931C8.01293 6.52997 8 6.59499 8 6.66065V9.66555H1.33333V2.99888H6.83333C6.96594 2.99887 7.0931 2.9462 7.18688 2.85244L7.52021 2.51911C7.83519 2.20411 7.6121 1.66555 7.16667 1.66555H1C0.447708 1.66555 0 2.11326 0 2.66555V9.99888C0 10.5512 0.447708 10.9989 1 10.9989H8.33333C8.88562 10.9989 9.33333 10.5512 9.33333 9.99888V6.3273C9.33333 5.88184 8.79475 5.65876 8.47977 5.97376Z'
+      fill={colors.palette.neutralThin}
+    />
+  </svg>
+);
 
-export const useHelpMenu = (actions: {label: string; callback: () => void}[] = []) => {
+export interface HelpMenuProps {
+  contactFormParams: { key: string; value: string }[];
+  children?: React.ReactNode;
+}
+
+export const HelpMenu: React.FC<HelpMenuProps> = ({ contactFormParams, children }) => {
   const [showIframe, setShowIframe] = React.useState<string | undefined>();
 
-  function HelpMenu({contactFormParams}: {contactFormParams: { key: string; value: string }[]}) {
-    const contactFormUrl = React.useMemo(() => {
-      const formUrl = 'https://openstax.org/embedded/contact';
-      const params = contactFormParams
-        .map(({key, value}) => encodeURIComponent(`${key}=${value}`))
-        .map((p) => `body=${p}`)
-        .join('&');
+  const contactFormUrl = React.useMemo(() => {
+    const formUrl = 'https://openstax.org/embedded/contact';
+    const params = contactFormParams
+      .map(({key, value}) => encodeURIComponent(`${key}=${value}`))
+      .map((p) => `body=${p}`)
+      .join('&');
 
-      return `${formUrl}?${params}`;
-    }, [contactFormParams]);
+    return `${formUrl}?${params}`;
+  }, [contactFormParams]);
 
-    return (
-      <>
-        <styledMenu.Button label='Help' aria-label='Help menu'>
-          {actions.map((action, i) => <styledMenu.Item key={i} onAction={action.callback}>
-            {action.label}
-          </styledMenu.Item>
-          )}
-          <styledMenu.Item
-            onAction={() => setShowIframe(contactFormUrl)}
-          >
-            Report an issue
-          </styledMenu.Item>
-          <styledMenu.Item
-            href='https://help.openstax.org/s/global-search/assignable'
-            target='_blank'
-          >
-            Support center&nbsp;
-            {newTabIcon}
-          </styledMenu.Item>
-          <styledMenu.Item
-            href='https://openstax.org/accessibility-statement'
-            target='_blank'
-          >
-            Accessibility statement&nbsp;
-            {newTabIcon}
-          </styledMenu.Item>
-          <styledMenu.Item
-            onAction={() => {
-              window.parent.postMessage({type: 'TriggerConsentModalMessage'}, '*');
-            }}
-          >
-            Cookie settings
-          </styledMenu.Item>
-        </styledMenu.Button>
-      </>
-    );
-  }
+  React.useEffect(() => {
+    const closeIt = ({data}: MessageEvent) => {
+      if (data === 'CONTACT_FORM_SUBMITTED') {
+        setShowIframe(undefined);
+      }
+    };
 
-  function ContactFormIframe() {
-    React.useEffect(
-      () => {
-        const closeIt = ({data}: MessageEvent) => {
-          if (data === 'CONTACT_FORM_SUBMITTED') {
-            setShowIframe(undefined);
-          }
-        };
+    window.addEventListener('message', closeIt, false);
+    return () => window.removeEventListener('message', closeIt, false);
+  }, []);
 
-        window.addEventListener('message', closeIt, false);
+  return (
+    <>
+      <HelpMenuButton label='Help' aria-label='Help menu'>
+        <HelpMenuItem onAction={() => setShowIframe(contactFormUrl)}>
+          Report an issue
+        </HelpMenuItem>
+        {children}
+      </HelpMenuButton>
 
-        return () => window.removeEventListener('message', closeIt, false);
-      },
-      []
-    );
-
-    if (!showIframe) {
-      return null;
-    }
-
-    return (
-      <IframeWrapper>
-        <Iframe title='Contact form' src={showIframe} />
-        <StyledPutAway onClick={() => setShowIframe(undefined)} />
-      </IframeWrapper>
-    );
-  }
-
-  return [HelpMenu, ContactFormIframe] as const;
+      {showIframe && (
+        <IframeWrapper>
+          <Iframe title='Contact form' src={showIframe} />
+          <StyledPutAway onClick={() => setShowIframe(undefined)} />
+        </IframeWrapper>
+      )}
+    </>
+  );
 };

--- a/src/components/__snapshots__/HelpMenu.spec.tsx.snap
+++ b/src/components/__snapshots__/HelpMenu.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useHelpMenu matches snapshot 1`] = `
+exports[`HelpMenu matches snapshot 1`] = `
 <body>
   <nav
     class="sc-jqUVSM cCVOTe"
@@ -53,7 +53,7 @@ exports[`useHelpMenu matches snapshot 1`] = `
         aria-expanded="false"
         aria-haspopup="true"
         aria-label="Help menu"
-        class="sc-bczRLJ dKgZvy sc-eCYdqJ jbRqSg"
+        class="sc-bczRLJ dKgZvy sc-eCYdqJ henMfs"
         data-rac=""
         id="react-aria-1"
         type="button"


### PR DESCRIPTION
refactor: Split styledMenu into separate HelpMenuButton and HelpMenuItem components
docs: improve release instructions and tag usage guidelines in README

[CORE-642] 

This PR blocks https://github.com/openstax/assignments/pull/263

[CORE-642]: https://openstax.atlassian.net/browse/CORE-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ