### PR TITLE
CORE-675: refactor togglebuttongroup children prop

### DIFF
--- a/src/components/SectionNav.stories.tsx
+++ b/src/components/SectionNav.stories.tsx
@@ -71,7 +71,7 @@ export const WithToggleButtonGroups = () => {
   const [selectedItems, setSelectedItems] = React.useState(new Set<Key>([flattenedSections[0].id]));
 
   const scrollToIndex = (id: Key) => {
-    const child = document.querySelector(`[data-section-id="${id}"]`) as HTMLElement;
+    const child = document.querySelector(`[data-button-id="${id}"]`) as HTMLElement;
     if (child) {
       child.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
     }
@@ -104,14 +104,13 @@ export const WithToggleButtonGroups = () => {
   };
 
   const ToggleGroup = sections.map(
-    (section, index) => 
+    (sectionSet, index) => 
       <ToggleButtonGroup
         key={`section-${index + 1}`}
         selectedItems={selectedItems}
         onSelectionChange={setSelectedItems}
-      >
-        {section}
-      </ToggleButtonGroup>
+        items={sectionSet}
+      />
   );
 
   return (

--- a/src/components/ToggleButtonGroup.spec.tsx
+++ b/src/components/ToggleButtonGroup.spec.tsx
@@ -17,9 +17,8 @@ describe('ToggleButtonGroup', () => {
       <ToggleButtonGroup
         selectionMode='single'
         selectedItems={new Set(['red'])}
-      >
-        {childrenListWithKeys}
-      </ToggleButtonGroup>
+        items={childrenListWithKeys}
+      />
     );
     const button = component.root.findByProps({ id: 'red' });
     button.props.onPressStart(mockEvent);
@@ -36,9 +35,8 @@ describe('ToggleButtonGroup', () => {
             <ToggleButtonGroup 
                 selectionMode={selectionMode}
                 selectedItems={new Set(['red'])}
-            >
-                {childrenListWithKeys}
-            </ToggleButtonGroup>
+                items={childrenListWithKeys}
+            />
         ).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/src/components/ToggleButtonGroup.stories.tsx
+++ b/src/components/ToggleButtonGroup.stories.tsx
@@ -18,9 +18,8 @@ export const MultipleSelection = () => {
         selectionMode='multiple'
         selectedItems={selectedItems}
         onSelectionChange={setSelectedItems}
-      >
-        {childrenListWithKeys}
-      </ToggleButtonGroup>
+        items={childrenListWithKeys}
+      />
       <p>Current selections: {[...selectedItems].join(', ')}</p>
     </>
   );
@@ -33,9 +32,8 @@ export const SingleSelection = () => {
       <ToggleButtonGroup
         selectedItems={selectedItems}
         onSelectionChange={setSelectedItems}
-      >
-        {childrenListWithKeys}
-      </ToggleButtonGroup>
+        items={childrenListWithKeys}
+      />
       <p>Current selections: {[...selectedItems].join(', ')}</p>
     </>
   );

--- a/src/components/ToggleButtonGroup/index.tsx
+++ b/src/components/ToggleButtonGroup/index.tsx
@@ -3,7 +3,7 @@ import { StyledToggleButtonGroup, StyledToggleButton } from "./styles";
 import { Key } from "react-aria-components";
 
 export interface ToggleButtonGroupProps {
-  children: { id: string, value: string }[];
+  items: { id: string, value: string }[];
   selectedItems: Set<Key>;
   onSelectionChange?: React.Dispatch<React.SetStateAction<Set<Key>>>;
   selectionMode?: 'single' | 'multiple';
@@ -14,7 +14,7 @@ export const ToggleButton = StyledToggleButton;
 
 export const ToggleButtonGroup = (
   {
-    children,
+    items,
     selectedItems,
     onSelectionChange,
     selectionMode = 'single',
@@ -28,15 +28,15 @@ export const ToggleButtonGroup = (
       onSelectionChange={onSelectionChange}
       {...props}
     >
-      {children.map((child) =>
+      {items.map((item) =>
         <StyledToggleButton
-          key={child.id}
-          data-section-id={child.id}
-          id={child.id}
+          key={item.id}
+          data-button-id={item.id}
+          id={item.id}
           // Allow parents to trigger handlers, works with onPointer events but not with onMouse events
           onPressStart={e => e.continuePropagation()}
         >
-          {child.value}
+          {item.value}
         </StyledToggleButton>
       )}
     </StyledToggleButtonGroup>

--- a/src/components/__snapshots__/ToggleButtonGroup.spec.tsx.snap
+++ b/src/components/__snapshots__/ToggleButtonGroup.spec.tsx.snap
@@ -14,8 +14,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode multiple 1`] = `
   <button
     aria-pressed={true}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="red"
     data-rac=""
-    data-section-id="red"
     data-selected={true}
     disabled={false}
     onBlur={[Function]}
@@ -38,8 +38,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode multiple 1`] = `
   <button
     aria-pressed={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="green"
     data-rac=""
-    data-section-id="green"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -61,8 +61,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode multiple 1`] = `
   <button
     aria-pressed={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="blue"
     data-rac=""
-    data-section-id="blue"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -84,8 +84,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode multiple 1`] = `
   <button
     aria-pressed={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="yellow"
     data-rac=""
-    data-section-id="yellow"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -107,8 +107,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode multiple 1`] = `
   <button
     aria-pressed={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="orange"
     data-rac=""
-    data-section-id="orange"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -144,8 +144,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode single 1`] = `
   <button
     aria-checked={true}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="red"
     data-rac=""
-    data-section-id="red"
     data-selected={true}
     disabled={false}
     onBlur={[Function]}
@@ -169,8 +169,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode single 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="green"
     data-rac=""
-    data-section-id="green"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -193,8 +193,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode single 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="blue"
     data-rac=""
-    data-section-id="blue"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -217,8 +217,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode single 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="yellow"
     data-rac=""
-    data-section-id="yellow"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -241,8 +241,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode single 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="orange"
     data-rac=""
-    data-section-id="orange"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -279,8 +279,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode undefined 1`] = `
   <button
     aria-checked={true}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="red"
     data-rac=""
-    data-section-id="red"
     data-selected={true}
     disabled={false}
     onBlur={[Function]}
@@ -304,8 +304,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode undefined 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="green"
     data-rac=""
-    data-section-id="green"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -328,8 +328,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode undefined 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="blue"
     data-rac=""
-    data-section-id="blue"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -352,8 +352,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode undefined 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="yellow"
     data-rac=""
-    data-section-id="yellow"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -376,8 +376,8 @@ exports[`ToggleButtonGroup matches snapshot with selectionMode undefined 1`] = `
   <button
     aria-checked={false}
     className="sc-dkzDqf jDeGjH"
+    data-button-id="orange"
     data-rac=""
-    data-section-id="orange"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}


### PR DESCRIPTION
[CORE-675]

Remove children from ToggleButtonGroup and pass it as a new prop called items 

[CORE-675]: https://openstax.atlassian.net/browse/CORE-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ