### PR TITLE
CORE-951 - Use `beforeCapture` to set level in Sentry scope

### DIFF
--- a/src/components/ErrorBoundary.spec.tsx
+++ b/src/components/ErrorBoundary.spec.tsx
@@ -118,21 +118,14 @@ describe('ErrorBoundary', () => {
 
     // Round 1: Override default 'warning' level with 'debug'
     // Should create debug (reports[0])
-    const tree = renderer.create(
+    renderer.create(
       <ErrorBoundary
         renderFallback
-        errorFallbacks={{
-          SessionExpiredError: {
-            element: <>session expired</>,
-            level: 'debug'
-          }
-        }}
+        errorLevels={{ SessionExpiredError: 'debug' }}
       >
         <SessionExpiredComponent />
       </ErrorBoundary>
     );
-    
-    expect(tree).toMatchInlineSnapshot(`"session expired"`);
 
     // Should create error (reports[1])
     renderer.create(
@@ -149,18 +142,16 @@ describe('ErrorBoundary', () => {
     // Round 2: Ensure 'error' level is default
     testkit.reset();
 
-    expect(renderer.create(
+    const unsetLevel = (undefined as unknown) as Sentry.SeverityLevel
+
+    renderer.create(
       <ErrorBoundary
         renderFallback
-        errorFallbacks={{
-          SessionExpiredError: {
-            element: <>I'm an error</>
-          }
-        }}
+        errorLevels={{ SessionExpiredError: unsetLevel }}
       >
         <SessionExpiredComponent />
       </ErrorBoundary>
-    )).toMatchInlineSnapshot(`"I'm an error"`);
+    );
 
     expect(testkit.reports()).toHaveLength(1);
     expect(testkit.reports()[0].level).toBe('error');

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -21,6 +21,7 @@ const defaultErrorFallbacks = {
 };
 
 const defaultErrorLevels: { [_: string]: Sentry.SeverityLevel } = {
+  'ScoresSyncError': 'warning',
   'SessionExpiredError': 'warning'
 };
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -20,6 +20,11 @@ const defaultErrorFallbacks = {
   </Error>
 };
 
+const errorLevelByType: Record<string, Sentry.SeverityLevel> = {
+  'ScoresSyncError': 'warning',
+  'SessionExpiredError': 'warning'
+}
+
 export const ErrorBoundary = ({
   children,
   renderFallback,
@@ -78,6 +83,14 @@ export const ErrorBoundary = ({
       }}
       {...props}
       onReset={() => setError(null)}
+      beforeCapture={(scope, error) => {
+        if (error) {
+          const type = getTypeFromError(error);
+          if (type in errorLevelByType) {
+            scope.setLevel(errorLevelByType[type]);
+          }
+        }
+      }}
     >
       {renderElement}
     </Sentry.ErrorBoundary>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -21,7 +21,6 @@ const defaultErrorFallbacks = {
 };
 
 const defaultErrorLevels: { [_: string]: Sentry.SeverityLevel } = {
-  'ScoresSyncError': 'warning',
   'SessionExpiredError': 'warning'
 };
 
@@ -85,7 +84,7 @@ export const ErrorBoundary = ({
       }}
       beforeCapture={(scope, error) => {
         // We need to set the level here, before `setError` is called in `onError`
-        // throw -> beforeCapture -> error captured -> onError -> setError -> etc.
+        // throw -> beforeCapture -> onError -> error captured -> setError -> etc.
         if (error) {
           const type = getTypeFromError(error);
           const errorLevel = errorLevels[type];


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-951

Only set level if there is a reason to (override exists)

```
beforeCapture (Function)
(Available in version 5.20.0 and above)

A function that gets called before an error is sent to Sentry, allowing for extra tags or context to be added to the error.
```

...and a helpful [link](https://docs.sentry.io/platforms/javascript/guides/react/features/error-boundary/) to the source too.