### PR TITLE
use correct version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "license": "MIT",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1027
Didn't realize we already had a `1.18.1`.