### PR TITLE
CORE-1996: Setup Jest configuration for CSS imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,4 +13,7 @@ module.exports = {
     "json",
     "node"
   ],
+  "moduleNameMapper": {
+    "^.+\\.css$": "identity-obj-proxy"
+  },
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^5.0.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^29.3.1",
     "jest-environment-node": "^29.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8775,6 +8775,11 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -8953,6 +8958,13 @@ icss-utils@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@1.1.13:
   version "1.1.13"


### PR DESCRIPTION
## Summary
This PR sets up Jest configuration to handle CSS imports, preparing the test environment for the migration from styled-components to plain CSS.

## Changes
- Added `identity-obj-proxy` as a devDependency for mocking CSS imports in tests
- Configured Jest `moduleNameMapper` to handle CSS files with identity-obj-proxy
- Verified that all existing tests still run successfully

## Related Issues
- Subtask: https://openstax.atlassian.net/browse/CORE-1996
- Parent: https://openstax.atlassian.net/browse/CORE-1777

## Testing
- Ran full test suite: `yarn test`
- All tests pass (1 pre-existing snapshot failure unrelated to this change)

## Notes
This is part of Phase 1 of the styled-components to plain CSS migration. The next step will be updating theme files to remove styled-components imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)