### PR TITLE
sync css to build output

### DIFF
--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -9,4 +9,7 @@ cd "$project_dir"
 tsc_args=(--noEmit false --declaration)
 
 yarn -s tsc --project tsconfig.without-specs.esm.json "${tsc_args[@]}"
+rsync -av --prune-empty-dirs --include="*.css" --include="*/" --exclude="*" src/ dist/esm/
+
 yarn -s tsc --project tsconfig.without-specs.cjs.json "${tsc_args[@]}"
+rsync -av --prune-empty-dirs --include="*.css" --include="*/" --exclude="*" src/ dist/cjs/


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1777

my previous change to replace microbundle with tsc build would have broken the css imports, this adds them back to the build output