### PR TITLE
fix import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "module": "index.js",
+  "types": "index.d.ts",
   "exports": {
     ".": {
       "browser": "./dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import styled, {css} from "styled-components";
-import theme from '../../src/theme';
+import theme from '../theme';
 import { applyButtonVariantStyles, ButtonVariant } from "../theme/buttons";
 
 export { applyButtonVariantStyles };

--- a/src/components/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { ErrorMessage } from "./ErrorMessage";
 import { UnauthorizedError, SessionExpiredError } from "@openstax/ts-utils/errors";
-import { useSetAppError } from "../../src/hooks";
+import { useSetAppError } from "../hooks";
 
 const ErrorComponent = ({ doThrow, setShowError, error: error, errorMessage }: {
   doThrow: boolean;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { colors, zIndex } from "../../src/theme";
+import { colors, zIndex } from "../theme";
 import { CloseModalButton } from "./CloseModalButton";
 import * as RAC from "react-aria-components";
 import React from "react";

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -1,4 +1,4 @@
-import { colors } from "../../src/theme";
+import { colors } from "../theme";
 import styled from "styled-components";
 import { NavBar } from "./NavBar";
 import { NavBarButton } from "./NavBarButton";

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
-import * as Constants from '../../src/constants';
-import theme from '../../src/theme';
+import * as Constants from '../constants';
+import theme from '../theme';
 import { BodyPortal } from './BodyPortal';
 import { NavBarLogo as OpenstaxLogo } from './NavBarLogo';
 

--- a/src/components/NavBarLogo.tsx
+++ b/src/components/NavBarLogo.tsx
@@ -1,6 +1,6 @@
-import theme from "../../src/theme";
+import theme from "../theme";
 import styled, { css } from "styled-components";
-import { navLogoDesktopHeight, navLogoMobileHeight } from "../../src/constants";
+import { navLogoDesktopHeight, navLogoMobileHeight } from "../constants";
 
 
 const StyledLogo = styled.svg`

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -9,7 +9,7 @@ import {
   PopoverProps,
 } from "react-aria-components";
 import styled from "styled-components";
-import { colors, defaultFocusOutline } from "../../src/theme";
+import { colors, defaultFocusOutline } from "../theme";
 import { NavBarButton, NavBarButtonProps } from "./NavBarButton";
 
 export const NavBarMenuItem = styled(MenuItem)``;

--- a/src/components/SidebarNav.stories.tsx
+++ b/src/components/SidebarNav.stories.tsx
@@ -1,4 +1,4 @@
-import { useMatchMediaQuery } from "../../src/hooks";
+import { useMatchMediaQuery } from "../hooks";
 import styled, { createGlobalStyle, css } from "styled-components";
 import {
   BodyPortalSidebarNav,
@@ -10,7 +10,7 @@ import { BodyPortal } from "./BodyPortal";
 import { NavBar } from "./NavBar";
 import { NavBarLogo } from "./NavBarLogo";
 import React from "react";
-import { breakpoints, colors } from "../../src/theme";
+import { breakpoints, colors } from "../theme";
 import { NavBarPopoverButton, PopoverContainer } from "./NavBarMenuButtons";
 
 const GlobalStyle = createGlobalStyle`

--- a/src/components/SidebarNav/hooks.ts
+++ b/src/components/SidebarNav/hooks.ts
@@ -1,6 +1,6 @@
 import React from "react";
-import { useMatchMediaQuery } from "../../../src/hooks";
-import { breakpoints } from "../../../src/theme";
+import { useMatchMediaQuery } from "../../hooks";
+import { breakpoints } from "../../theme";
 
 export const useSidebarNavProps = ({
   mobileBreakpoint = `${breakpoints.mobileNavBreak}em`,

--- a/src/components/SidebarNav/styles.ts
+++ b/src/components/SidebarNav/styles.ts
@@ -1,4 +1,4 @@
-import { colors, zIndex } from "../../../src/theme";
+import { colors, zIndex } from "../../theme";
 import styled, { css } from "styled-components";
 
 export const collapsedWidth = "5.6rem";

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as RAC from "react-aria-components";
 import { colors } from "../theme";
 import styled, { css } from "styled-components";
-import { palette } from "../../src/theme/palette";
+import { palette } from "../theme/palette";
 
 export type TabsProps = {
   variant?: "button-bar";

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { colors } from '../../src/theme';
+import { colors } from '../theme';
 import styled, { css } from 'styled-components';
-import { ToastData } from '../../src/types';
+import { ToastData } from '../types';
 
 const ANIMATION_TIME_MS = 500;
 const DISMISS_AFTER_MS_FLOOR = 1000;

--- a/src/components/ToastContainer.spec.tsx
+++ b/src/components/ToastContainer.spec.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react';
 import { BodyPortalToastContainer, ToastContainer } from './ToastContainer';
-import { ToastData } from '../../src/types';
+import { ToastData } from '../types';
 
 jest.useFakeTimers();
 

--- a/src/components/ToastContainer.stories.tsx
+++ b/src/components/ToastContainer.stories.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ToastData } from '../../src/types';
+import { ToastData } from '../types';
 import { BodyPortalToastContainer, ToastContainer } from './ToastContainer';
 
 const StyledBodyPortalToastContainer = styled(BodyPortalToastContainer)`

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,8 +1,8 @@
 import styled, { css, ThemedStyledFunction } from 'styled-components';
 import { BodyPortal } from './BodyPortal';
 import { Toast } from './Toast';
-import { zIndex } from '../../src/theme';
-import { ToastData } from '../../src/types';
+import { zIndex } from '../theme';
+import { ToastData } from '../types';
 import { ComponentType } from 'react';
 
 const makeStyledToastContainer = <T extends keyof JSX.IntrinsicElements | ComponentType<any>>(

--- a/src/components/Tree/TreeCheckbox.tsx
+++ b/src/components/Tree/TreeCheckbox.tsx
@@ -12,7 +12,7 @@ import {
   CheckboxVariant 
 } from "../Checkbox/sharedCheckboxStyles";
 import { checkedMixIcon } from "../svgs/checkmarksvgs";
-import theme from '../../../src/theme';
+import theme from '../../theme';
 
 export interface TreeCheckboxProps
   extends PropsWithChildren<Omit<RACCheckboxProps, "children">> {


### PR DESCRIPTION
loosely related to previous change https://openstax.atlassian.net/browse/CORE-2202 

but mostly - when i swapped the build from bundling to just using the tsc output, the imports leaving and re-entering the src directory broke downstream builds

not sure if that was something that was always there or recently introduced by the styled-components refactor