### PR TITLE
CORE-1999: Migrate Button component and variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed - BREAKING CHANGES
+
+#### Button Component Migration (CORE-1999)
+
+The Button component and its variants have been migrated from styled-components to standard CSS with CSS custom properties. While the components maintain the same visual appearance and React API, there are **breaking changes** for certain exports:
+
+**Breaking Changes:**
+
+1. **`buttonCss` export**: Changed from a styled-components `css` fragment to a plain string (`'button-base'`)
+   - **Old behavior**: Was a styled-components CSS fragment that could be interpolated into styled components and included variant styles
+   - **New behavior**: Returns the string `'button-base'` (a CSS class name)
+   - **Impact**: Code that interpolates `buttonCss` into styled-components templates will break if it expects variant colors to be applied automatically. Callers must now also set CSS custom properties for colors.
+   - **Migration**: Use the Button components directly, or manually bind CSS custom properties when using the class
+
+2. **`linkStyle` export**: Changed from a styled-components `css` fragment to a plain CSS string
+   - **Old behavior**: Was a styled-components CSS fragment (`css` tagged template)
+   - **New behavior**: Returns a plain CSS string with the same styles
+   - **Impact**: Type incompatibility for consumers expecting `FlattenSimpleInterpolation`
+   - **Migration**: Can still be used in styled-components template literals, but the type has changed
+   - **Deprecated**: Use the `ButtonLink` component instead
+
+3. **`applyButtonVariantStyles` function**: Return type changed from `FlattenSimpleInterpolation` to plain string
+   - **Old behavior**: Returned styled-components `FlattenSimpleInterpolation` type
+   - **New behavior**: Returns a plain CSS string
+   - **Impact**: Type incompatibility for consumers
+   - **Migration**: Can still be used in styled-components template literals
+   - **Deprecated**: Use `getButtonVariantStyles()` with CSS custom properties instead
+
+**Non-Breaking Changes:**
+
+- All Button component props and behavior remain unchanged
+- Visual appearance is identical to previous implementation
+- All variants (Button, LinkButton, PlainButton, ButtonLink) maintain the same React API
+
 ## [v1.10.7] - 2024-10-22
 
 - Create custom styled checkbox

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import { DismissIcon } from "../svgs/DismissIcon";
 import { Html } from "../Html";
 import styled from 'styled-components';
-import { Button, ButtonLink } from '../Button';
+import { Button } from '../Button';
 import { colors } from '../../theme';
 
 export type BannerSeverity = 'note' | 'warning' | 'error';
@@ -32,7 +32,7 @@ export const StyledBanner = styled.div<{severity: BannerSeverity}>`
     }
   }
 
-  ${ButtonLink} {
+  .button-link {
     font-size: 1.6rem;
   }
 `;

--- a/src/components/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Banner matches snapshot (error, with dismiss) 1`] = `
 <div
-  className="sc-jSMfEi iGEqwr"
+  className="sc-gsnTZi bbCSY"
 >
   <div>
     <span
@@ -15,9 +15,20 @@ exports[`Banner matches snapshot (error, with dismiss) 1`] = `
   </div>
   <button
     aria-label="dismiss"
-    className="sc-bczRLJ sc-gKXOVf dOOknK dwyZcw"
+    className="button-base sc-dkzDqf dzRdnV"
     onClick={[Function]}
     severity="error"
+    style={
+      Object {
+        "--button-bg": "#D4450C",
+        "--button-bg-active": "#b03808",
+        "--button-bg-hover": "#be3c08",
+        "--button-color": "#ffffff",
+        "--button-font-weight": 700,
+        "--button-outline": "#ffffff",
+        "--button-shadow": "#000000",
+      }
+    }
   >
     <svg
       aria-hidden="true"
@@ -53,11 +64,11 @@ exports[`Banner matches snapshot (error, with dismiss) 1`] = `
 
 exports[`Banner matches snapshot (multiple messages, with dismiss) 1`] = `
 <div
-  className="sc-jSMfEi lmuhoy"
+  className="sc-gsnTZi iNpbIt"
 >
   <div>
     <span
-      className="sc-eCYdqJ EIRbC"
+      className="sc-bczRLJ jqtwgx"
     >
       Warning: 
     </span>
@@ -78,9 +89,20 @@ exports[`Banner matches snapshot (multiple messages, with dismiss) 1`] = `
   </div>
   <button
     aria-label="dismiss"
-    className="sc-bczRLJ sc-gKXOVf dOOknK fGvwkl"
+    className="button-base sc-dkzDqf cLwIlc"
     onClick={[Function]}
     severity="warning"
+    style={
+      Object {
+        "--button-bg": "#D4450C",
+        "--button-bg-active": "#b03808",
+        "--button-bg-hover": "#be3c08",
+        "--button-color": "#ffffff",
+        "--button-font-weight": 700,
+        "--button-outline": "#ffffff",
+        "--button-shadow": "#000000",
+      }
+    }
   >
     <svg
       aria-hidden="true"
@@ -116,11 +138,11 @@ exports[`Banner matches snapshot (multiple messages, with dismiss) 1`] = `
 
 exports[`Banner matches snapshot (single message, no dismiss) 1`] = `
 <div
-  className="sc-jSMfEi lmuhoy"
+  className="sc-gsnTZi iNpbIt"
 >
   <div>
     <span
-      className="sc-eCYdqJ EIRbC"
+      className="sc-bczRLJ jqtwgx"
     >
       Note: 
     </span>

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -1,0 +1,76 @@
+/* Base button styles */
+.button-base {
+  font-size: 1.6rem;
+  line-height: 2rem;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  height: 4rem;
+  padding: 0 3rem;
+  border: 0;
+  border-radius: 0.5rem;
+  box-shadow: 0px 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
+  transition: all 0.2s ease-in-out;
+  text-decoration: none;
+  user-select: none;
+  white-space: nowrap;
+
+  /* Variant-specific styles using CSS custom properties */
+  background-color: var(--button-bg);
+  color: var(--button-color);
+  font-weight: var(--button-font-weight);
+}
+
+.button-base:not([disabled]) {
+  cursor: pointer;
+}
+
+.button-base:disabled {
+  opacity: 0.4;
+}
+
+.button-base + .button-base {
+  margin-left: 1.6rem;
+}
+
+.button-base:not([disabled]):hover {
+  background: var(--button-bg-hover);
+}
+
+.button-base:not([disabled]):active {
+  background: var(--button-bg-active);
+}
+
+.button-base:focus {
+  outline: solid var(--button-outline);
+  box-shadow: inset 0 0 0 0.3rem var(--button-shadow);
+}
+
+/* Plain button - minimal styling */
+.plain-button {
+  cursor: pointer;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+}
+
+/* Button that looks like a link */
+.button-link {
+  cursor: pointer;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.button-link:hover,
+.button-link:focus {
+  text-decoration: underline;
+  color: var(--link-hover-color);
+}

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -18,10 +18,10 @@
   user-select: none;
   white-space: nowrap;
 
-  /* Variant-specific styles using CSS custom properties */
-  background-color: var(--button-bg);
-  color: var(--button-color);
-  font-weight: var(--button-font-weight);
+  /* Variant-specific styles using CSS custom properties with fallback defaults (primary variant) */
+  background-color: var(--button-bg, #d4450c);
+  color: var(--button-color, #ffffff);
+  font-weight: var(--button-font-weight, 700);
 }
 
 .button-base:not([disabled]) {
@@ -37,16 +37,16 @@
 }
 
 .button-base:not([disabled]):hover {
-  background: var(--button-bg-hover);
+  background: var(--button-bg-hover, #be3c08);
 }
 
 .button-base:not([disabled]):active {
-  background: var(--button-bg-active);
+  background: var(--button-bg-active, #b03808);
 }
 
 .button-base:focus {
-  outline: solid var(--button-outline);
-  box-shadow: inset 0 0 0 0.3rem var(--button-shadow);
+  outline: solid var(--button-outline, #ffffff);
+  box-shadow: inset 0 0 0 0.3rem var(--button-shadow, #424242);
 }
 
 /* Plain button - minimal styling */
@@ -65,12 +65,12 @@
   margin: 0;
   padding: 0;
   background: none;
-  color: var(--link-color);
+  color: var(--link-color, #026AA1);
   text-decoration: none;
 }
 
 .button-link:hover,
 .button-link:focus {
   text-decoration: underline;
-  color: var(--link-hover-color);
+  color: var(--link-hover-color, #005481);
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,6 +10,26 @@ export { applyButtonVariantStyles } from "../theme/buttons";
 // Export buttonCss as a string for backwards compatibility
 export const buttonCss = 'button-base';
 
+/**
+ * Link style CSS fragment for backwards compatibility.
+ *
+ * @deprecated This export is deprecated. Use the ButtonLink component instead.
+ * @note Breaking change: Previously returned a styled-components css fragment,
+ * now returns a plain CSS string. This is part of the migration away from styled-components.
+ * The string can still be used in styled-components template literals.
+ */
+export const linkStyle = `
+  color: ${theme.colors.link.color};
+  cursor: pointer;
+  text-decoration: none;
+
+  :hover,
+  :focus {
+    text-decoration: underline;
+    color: ${theme.colors.link.hover};
+  }
+`;
+
 interface ButtonOptions {
   variant?: ButtonVariant;
 }
@@ -70,7 +90,7 @@ Button.displayName = 'Button';
 
 export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonBase>(
   (props, ref) => {
-    const { variant = 'primary', className, style, ...otherProps } = props;
+    const { variant = 'primary', className, style, children, ...otherProps } = props;
 
     const variantStyles = getButtonVariantStyles(variant);
     const linkStyle = {
@@ -91,7 +111,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonBase>(
         className={classNames('button-base', className)}
         style={linkStyle}
       >
-        {props.children}
+        {children}
       </a>
     );
   }
@@ -101,14 +121,14 @@ LinkButton.displayName = 'LinkButton';
 
 export const PlainButton = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
   (props, ref) => {
-    const { className, ...otherProps } = props;
+    const { className, children, ...otherProps } = props;
     return (
       <button
         {...otherProps}
         ref={ref}
         className={classNames('plain-button', className)}
       >
-        {props.children}
+        {children}
       </button>
     );
   }
@@ -118,7 +138,7 @@ PlainButton.displayName = 'PlainButton';
 
 export const ButtonLink = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
   (props, ref) => {
-    const { className, style, ...otherProps } = props;
+    const { className, style, children, ...otherProps } = props;
 
     const linkStyleVars = {
       '--link-color': theme.colors.link.color,
@@ -133,7 +153,7 @@ export const ButtonLink = React.forwardRef<HTMLButtonElement, React.ComponentPro
         className={classNames('button-link', className)}
         style={linkStyleVars}
       >
-        {props.children}
+        {children}
       </button>
     );
   }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,40 +1,14 @@
-import styled, {css} from "styled-components";
+import React from 'react';
+import classNames from 'classnames';
 import theme from '../theme';
-import { applyButtonVariantStyles, ButtonVariant } from "../theme/buttons";
+import { getButtonVariantStyles, ButtonVariant } from "../theme/buttons";
+import './Button.css';
 
-export { applyButtonVariantStyles };
-export const buttonCss = css<{variant?: ButtonVariant}>`
-  ${props => applyButtonVariantStyles(props.variant || 'primary')}
+// Re-export for backwards compatibility
+export { applyButtonVariantStyles } from "../theme/buttons";
 
-  font-size: 1.6rem;
-  line-height: 2rem;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  display: inline-flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  height: 4rem;
-  padding: 0 3rem;
-  border: 0;
-  border-radius: 0.5rem;
-  box-shadow: 0px 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
-  transition: all 0.2s ease-in-out;
-  text-decoration: none;
-  user-select: none;
-  white-space: nowrap;
-
-  &:not([disabled]) {
-    cursor: pointer;
-  }
-  &:disabled {
-    opacity: 0.4;
-  }
-
-  & + & {
-    margin-left: 1.6rem;
-  }
-`;
+// Export buttonCss as a string for backwards compatibility
+export const buttonCss = 'button-base';
 
 interface ButtonOptions {
   variant?: ButtonVariant;
@@ -53,53 +27,116 @@ export interface WaitingButtonProps extends ButtonBase {
   waitingText: string;
 }
 
-export const Button = styled((props: ButtonProps | WaitingButtonProps) => {
-  const {
-    disabled,
-    isWaiting,
-    waitingText,
-    children,
-    variant,
-    ...otherProps
-  } = props;
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps | WaitingButtonProps>(
+  (props, ref) => {
+    const {
+      disabled,
+      isWaiting,
+      waitingText,
+      children,
+      variant = 'primary',
+      className,
+      style,
+      ...otherProps
+    } = props;
 
-  return <button
-    {...otherProps}
-    disabled={isWaiting || disabled}
-  >
-    {(isWaiting && waitingText) || children}
-  </button>;
-})`
-  ${buttonCss}
-`;
+    const variantStyles = getButtonVariantStyles(variant);
+    const buttonStyle = {
+      '--button-bg': variantStyles.background,
+      '--button-bg-hover': variantStyles.backgroundHover,
+      '--button-bg-active': variantStyles.backgroundActive,
+      '--button-color': variantStyles.color,
+      '--button-outline': variantStyles.outline,
+      '--button-shadow': variantStyles.shadow,
+      '--button-font-weight': variantStyles.fontWeight ?? 700,
+      ...style
+    } as React.CSSProperties;
 
-export const LinkButton = styled(({ variant, ...props}: LinkButtonBase) =>
-  <a {...props}>{props.children}</a>
-)`
-  ${buttonCss}
-`;
-
-export const linkStyle = css`
-  color: ${theme.colors.link.color};
-  cursor: pointer;
-  text-decoration: none;
-
-  :hover,
-  :focus {
-    text-decoration: underline;
-    color: ${theme.colors.link.hover};
+    return (
+      <button
+        {...otherProps}
+        ref={ref}
+        disabled={isWaiting || disabled}
+        className={classNames('button-base', className)}
+        style={buttonStyle}
+      >
+        {(isWaiting && waitingText) || children}
+      </button>
+    );
   }
-`;
+);
 
-export const PlainButton = styled.button`
-  cursor: pointer;
-  border: none;
-  margin: 0;
-  padding: 0;
-  background: none;
-`;
+Button.displayName = 'Button';
 
-// tslint:disable-next-line:variable-name
-export const ButtonLink = styled(PlainButton)`
-  ${linkStyle}
-`;
+export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonBase>(
+  (props, ref) => {
+    const { variant = 'primary', className, style, ...otherProps } = props;
+
+    const variantStyles = getButtonVariantStyles(variant);
+    const linkStyle = {
+      '--button-bg': variantStyles.background,
+      '--button-bg-hover': variantStyles.backgroundHover,
+      '--button-bg-active': variantStyles.backgroundActive,
+      '--button-color': variantStyles.color,
+      '--button-outline': variantStyles.outline,
+      '--button-shadow': variantStyles.shadow,
+      '--button-font-weight': variantStyles.fontWeight ?? 700,
+      ...style
+    } as React.CSSProperties;
+
+    return (
+      <a
+        {...otherProps}
+        ref={ref}
+        className={classNames('button-base', className)}
+        style={linkStyle}
+      >
+        {props.children}
+      </a>
+    );
+  }
+);
+
+LinkButton.displayName = 'LinkButton';
+
+export const PlainButton = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
+  (props, ref) => {
+    const { className, ...otherProps } = props;
+    return (
+      <button
+        {...otherProps}
+        ref={ref}
+        className={classNames('plain-button', className)}
+      >
+        {props.children}
+      </button>
+    );
+  }
+);
+
+PlainButton.displayName = 'PlainButton';
+
+export const ButtonLink = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
+  (props, ref) => {
+    const { className, style, ...otherProps } = props;
+
+    const linkStyleVars = {
+      '--link-color': theme.colors.link.color,
+      '--link-hover-color': theme.colors.link.hover,
+      ...style
+    } as React.CSSProperties;
+
+    return (
+      <button
+        {...otherProps}
+        ref={ref}
+        className={classNames('button-link', className)}
+        style={linkStyleVars}
+      >
+        {props.children}
+      </button>
+    );
+  }
+);
+
+ButtonLink.displayName = 'ButtonLink';

--- a/src/components/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/__snapshots__/Button.spec.tsx.snap
@@ -2,8 +2,19 @@
 
 exports[`Button isWaiting state matches snapshot 1`] = `
 <button
-  className="sc-bczRLJ dOOknK"
+  className="button-base"
   disabled={true}
+  style={
+    Object {
+      "--button-bg": "#D4450C",
+      "--button-bg-active": "#b03808",
+      "--button-bg-hover": "#be3c08",
+      "--button-color": "#ffffff",
+      "--button-font-weight": 700,
+      "--button-outline": "#ffffff",
+      "--button-shadow": "#000000",
+    }
+  }
 >
   Submitting...
 </button>
@@ -11,7 +22,18 @@ exports[`Button isWaiting state matches snapshot 1`] = `
 
 exports[`Button matches light color snapshot 1`] = `
 <button
-  className="sc-bczRLJ esoxNv"
+  className="button-base"
+  style={
+    Object {
+      "--button-bg": "#ffffff",
+      "--button-bg-active": "#e5e5e5",
+      "--button-bg-hover": "#ffffff",
+      "--button-color": "#424242",
+      "--button-font-weight": 400,
+      "--button-outline": "#ffffff",
+      "--button-shadow": "#000000",
+    }
+  }
 >
   Click Me
 </button>
@@ -19,7 +41,18 @@ exports[`Button matches light color snapshot 1`] = `
 
 exports[`Button matches snapshot 1`] = `
 <button
-  className="sc-bczRLJ dOOknK"
+  className="button-base"
+  style={
+    Object {
+      "--button-bg": "#D4450C",
+      "--button-bg-active": "#b03808",
+      "--button-bg-hover": "#be3c08",
+      "--button-color": "#ffffff",
+      "--button-font-weight": 700,
+      "--button-outline": "#ffffff",
+      "--button-shadow": "#000000",
+    }
+  }
 >
   Click Me
 </button>
@@ -27,7 +60,18 @@ exports[`Button matches snapshot 1`] = `
 
 exports[`Button renders as a tag 1`] = `
 <a
-  className="sc-gsnTZi bOGeQ"
+  className="button-base"
+  style={
+    Object {
+      "--button-bg": "#D4450C",
+      "--button-bg-active": "#b03808",
+      "--button-bg-hover": "#be3c08",
+      "--button-color": "#ffffff",
+      "--button-font-weight": 700,
+      "--button-outline": "#ffffff",
+      "--button-shadow": "#000000",
+    }
+  }
 >
   Click Me
 </a>
@@ -35,7 +79,18 @@ exports[`Button renders as a tag 1`] = `
 
 exports[`Button renders as a tag variant 1`] = `
 <a
-  className="sc-gsnTZi gaKcuZ"
+  className="button-base"
+  style={
+    Object {
+      "--button-bg": "#ffffff",
+      "--button-bg-active": "#e5e5e5",
+      "--button-bg-hover": "#ffffff",
+      "--button-color": "#424242",
+      "--button-font-weight": 400,
+      "--button-outline": "#ffffff",
+      "--button-shadow": "#000000",
+    }
+  }
 >
   Click Me
 </a>
@@ -43,7 +98,13 @@ exports[`Button renders as a tag variant 1`] = `
 
 exports[`Button renders button that looks like a link 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm"
+  className="button-link"
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   Click Me
 </button>
@@ -51,7 +112,7 @@ exports[`Button renders button that looks like a link 1`] = `
 
 exports[`Button renders plain button 1`] = `
 <button
-  className="sc-dkzDqf bLbJrC"
+  className="plain-button"
 >
   Click Me
 </button>

--- a/src/components/__snapshots__/ErrorModal.spec.tsx.snap
+++ b/src/components/__snapshots__/ErrorModal.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Modal matches snapshot 1`] = `
     hidden=""
   />
   <div
-    class="sc-jqUVSM mLxLT"
+    class="sc-gKXOVf fbFzda"
     data-rac=""
     style="--visual-viewport-height: 768px;"
   >
@@ -31,20 +31,20 @@ exports[`Modal matches snapshot 1`] = `
         />
       </div>
       <div
-        class="sc-kDDrLX kcRDJd"
+        class="sc-iBkjds mgorR"
       >
         <section
           aria-labelledby="react-aria-2"
-          class="sc-jSMfEi jOuQOj"
+          class="sc-gsnTZi gQTek"
           data-rac=""
           role="dialog"
           tabindex="-1"
         >
           <header
-            class="sc-gKXOVf fMZXQS"
+            class="sc-dkzDqf gXnWMX"
           >
             <h2
-              class="sc-iBkjds crmGxr"
+              class="sc-hKMtZM gKFAwv"
               id="react-aria-2"
               slot="title"
             >
@@ -52,7 +52,7 @@ exports[`Modal matches snapshot 1`] = `
             </h2>
             <button
               aria-label="Close"
-              class="sc-eCYdqJ dRnxZp"
+              class="sc-bczRLJ elXiRy"
               type="button"
             >
               <svg
@@ -86,11 +86,11 @@ exports[`Modal matches snapshot 1`] = `
             </button>
           </header>
           <div
-            class="sc-breuTD eiboLU"
+            class="sc-kDDrLX jaUAqV"
             data-testid="error"
           >
             <h3
-              class="sc-evZas buXsYK"
+              class="sc-jqUVSM iTXlJL"
             >
               Uh-oh, there's been a glitch
             </h3>
@@ -103,15 +103,16 @@ exports[`Modal matches snapshot 1`] = `
             </a>
             .
             <div
-              class="sc-ksZaOG cPKkuS"
+              class="sc-iqcoie hdouAN"
               data-testid="event-id"
             />
           </div>
           <div
-            class="sc-iqcoie cqUGeK"
+            class="sc-ftvSup dVGJds"
           >
             <button
-              class="sc-bczRLJ dOOknK"
+              class="button-base"
+              style="--button-bg: #D4450C; --button-bg-hover: #be3c08; --button-bg-active: #b03808; --button-color: #ffffff; --button-outline: #ffffff; --button-shadow: #000000; --button-font-weight: 700;"
             >
               OK
             </button>
@@ -140,7 +141,7 @@ exports[`Modal matches snapshot when heading and children are set 1`] = `
     hidden=""
   />
   <div
-    class="sc-jqUVSM mLxLT"
+    class="sc-gKXOVf fbFzda"
     data-rac=""
     style="--visual-viewport-height: 768px;"
   >
@@ -159,20 +160,20 @@ exports[`Modal matches snapshot when heading and children are set 1`] = `
         />
       </div>
       <div
-        class="sc-kDDrLX kcRDJd"
+        class="sc-iBkjds mgorR"
       >
         <section
           aria-labelledby="react-aria-4"
-          class="sc-jSMfEi jOuQOj"
+          class="sc-gsnTZi gQTek"
           data-rac=""
           role="dialog"
           tabindex="-1"
         >
           <header
-            class="sc-gKXOVf fMZXQS"
+            class="sc-dkzDqf gXnWMX"
           >
             <h2
-              class="sc-iBkjds crmGxr"
+              class="sc-hKMtZM gKFAwv"
               id="react-aria-4"
               slot="title"
             >
@@ -180,7 +181,7 @@ exports[`Modal matches snapshot when heading and children are set 1`] = `
             </h2>
             <button
               aria-label="Close"
-              class="sc-eCYdqJ dRnxZp"
+              class="sc-bczRLJ elXiRy"
               type="button"
             >
               <svg
@@ -214,11 +215,11 @@ exports[`Modal matches snapshot when heading and children are set 1`] = `
             </button>
           </header>
           <div
-            class="sc-breuTD eiboLU"
+            class="sc-kDDrLX jaUAqV"
             data-testid="error"
           >
             <h3
-              class="sc-evZas buXsYK"
+              class="sc-jqUVSM iTXlJL"
             >
               Scores not sent
             </h3>
@@ -232,15 +233,16 @@ exports[`Modal matches snapshot when heading and children are set 1`] = `
             </a>
             .
             <div
-              class="sc-ksZaOG cPKkuS"
+              class="sc-iqcoie hdouAN"
               data-testid="event-id"
             />
           </div>
           <div
-            class="sc-iqcoie cqUGeK"
+            class="sc-ftvSup dVGJds"
           >
             <button
-              class="sc-bczRLJ dOOknK"
+              class="button-base"
+              style="--button-bg: #D4450C; --button-bg-hover: #be3c08; --button-bg-active: #b03808; --button-color: #ffffff; --button-outline: #ffffff; --button-shadow: #000000; --button-font-weight: 700;"
             >
               OK
             </button>

--- a/src/components/__snapshots__/ManageCookies.spec.tsx.snap
+++ b/src/components/__snapshots__/ManageCookies.spec.tsx.snap
@@ -2,8 +2,14 @@
 
 exports[`ManageCookies when CookieYes loads renders button 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+  className="button-link cky-banner-element"
   onClick={[Function]}
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   Manage Cookies
 </button>
@@ -12,8 +18,14 @@ exports[`ManageCookies when CookieYes loads renders button 1`] = `
 exports[`ManageCookies when CookieYes loads renders button in wrapper 1`] = `
 <div>
   <button
-    className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+    className="button-link cky-banner-element"
     onClick={[Function]}
+    style={
+      Object {
+        "--link-color": "#026AA1",
+        "--link-hover-color": "#005481",
+      }
+    }
   >
     Manage Cookies
   </button>
@@ -22,8 +34,14 @@ exports[`ManageCookies when CookieYes loads renders button in wrapper 1`] = `
 
 exports[`ManageCookies when CookieYes loads renders button with className 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element test"
+  className="button-link cky-banner-element test"
   onClick={[Function]}
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   Manage Cookies
 </button>
@@ -31,8 +49,14 @@ exports[`ManageCookies when CookieYes loads renders button with className 1`] = 
 
 exports[`ManageCookies when CookieYes loads renders button with content and correct class 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+  className="button-link cky-banner-element"
   onClick={[Function]}
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   some content
 </button>
@@ -40,8 +64,14 @@ exports[`ManageCookies when CookieYes loads renders button with content and corr
 
 exports[`ManageCookies with CookieYes already loaded renders button 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+  className="button-link cky-banner-element"
   onClick={[Function]}
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   Manage Cookies
 </button>
@@ -50,8 +80,14 @@ exports[`ManageCookies with CookieYes already loaded renders button 1`] = `
 exports[`ManageCookies with CookieYes already loaded renders button in wrapper 1`] = `
 <div>
   <button
-    className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+    className="button-link cky-banner-element"
     onClick={[Function]}
+    style={
+      Object {
+        "--link-color": "#026AA1",
+        "--link-hover-color": "#005481",
+      }
+    }
   >
     Manage Cookies
   </button>
@@ -60,8 +96,14 @@ exports[`ManageCookies with CookieYes already loaded renders button in wrapper 1
 
 exports[`ManageCookies with CookieYes already loaded renders button with content and correct class 1`] = `
 <button
-  className="sc-dkzDqf sc-hKMtZM bLbJrC bAtAjm cky-banner-element"
+  className="button-link cky-banner-element"
   onClick={[Function]}
+  style={
+    Object {
+      "--link-color": "#026AA1",
+      "--link-hover-color": "#005481",
+    }
+  }
 >
   some content
 </button>

--- a/src/theme/buttons.ts
+++ b/src/theme/buttons.ts
@@ -45,11 +45,23 @@ const buttonStyleSets = asButtonStyleSetTypes({
 } as const);
 
 /**
+ * Gets the button style set for a specific variant.
+ * Use this for binding theme colors to CSS custom properties.
+ *
+ * @param variant - The button variant to get styles for
+ * @returns ButtonStyleSet containing all variant-specific colors
+ */
+export const getButtonVariantStyles = (variant: ButtonVariant): ButtonStyleSet => {
+  return buttonStyleSets[variant];
+};
+
+/**
  * Applies button variant styles based on the specified variant.
  *
  * @param variant - The button variant to apply
  * @returns CSS string with button styles
  * @type {CssFragment}
+ * @deprecated This function is deprecated. Use getButtonVariantStyles() with CSS custom properties instead.
  * @note Breaking change: Previously returned FlattenSimpleInterpolation from styled-components,
  * now returns a plain string. This is part of the migration away from styled-components.
  * The string can still be used in styled-components template literals.

--- a/src/theme/buttons.ts
+++ b/src/theme/buttons.ts
@@ -51,7 +51,7 @@ const buttonStyleSets = asButtonStyleSetTypes({
  * @param variant - The button variant to get styles for
  * @returns ButtonStyleSet containing all variant-specific colors
  */
-export const getButtonVariantStyles = (variant: ButtonVariant): ButtonStyleSet => {
+export const getButtonVariantStyles = (variant: ButtonVariant) => {
   return buttonStyleSets[variant];
 };
 


### PR DESCRIPTION
## Summary

Migrates the Button component and its variants (PlainButton, LinkButton, ButtonLink) from styled-components to standard CSS with classNames.

Related Jira ticket: [CORE-1999](https://openstax.atlassian.net/browse/CORE-1999)

## Changes

### Components Migrated
- ✅ **Button** - Converted to React.forwardRef with CSS classes and CSS custom properties
- ✅ **LinkButton** - Converted to React.forwardRef for anchor elements
- ✅ **PlainButton** - Converted to React.forwardRef with plain-button class
- ✅ **ButtonLink** - Converted to React.forwardRef with button-link class

### Files Changed
- Created `src/components/Button.css` with all button styles using CSS custom properties (with fallback defaults)
- Updated `src/components/Button.tsx` to use classNames and React.forwardRef
- Added `getButtonVariantStyles()` helper in `src/theme/buttons.ts` for runtime CSS variable binding
- Re-exported `linkStyle` for backwards compatibility
- Fixed `src/components/Banner/Banner.tsx` to use CSS class selector instead of component selector
- Updated test snapshots
- Documented breaking changes in `CHANGELOG.md`

### Migration Strategy
Uses CSS custom properties to bind theme colors at runtime:
```typescript
const variantStyles = getButtonVariantStyles(variant || 'primary');
const buttonStyle = {
  '--button-bg': variantStyles.background,
  '--button-bg-hover': variantStyles.backgroundHover,
  '--button-bg-active': variantStyles.backgroundActive,
  '--button-color': variantStyles.color,
  '--button-outline': variantStyles.outline,
  '--button-shadow': variantStyles.shadow,
  '--button-font-weight': variantStyles.fontWeight ?? 700,
  ...style
} as React.CSSProperties;
```

CSS custom properties include fallback defaults (primary variant colors) to ensure buttons render correctly even if CSS variables are not set:
```css
background-color: var(--button-bg, #d4450c);
color: var(--button-color, #ffffff);
```

## Breaking Changes ⚠️

While the components maintain the same visual appearance and React API, there are **breaking changes** for certain exports:

### 1. `buttonCss` export
- **Old behavior**: Was a styled-components `css` fragment that could be interpolated into styled components and included variant styles
- **New behavior**: Returns the string `'button-base'` (a CSS class name)
- **Impact**: Code that interpolates `buttonCss` into styled-components templates will break if it expects variant colors to be applied automatically. Callers must now also set CSS custom properties for colors.
- **Migration**: Use the Button components directly, or manually bind CSS custom properties when using the class

### 2. `linkStyle` export
- **Old behavior**: Was a styled-components `css` fragment (`css` tagged template)
- **New behavior**: Returns a plain CSS string with the same styles
- **Impact**: Type incompatibility for consumers expecting `FlattenSimpleInterpolation`
- **Migration**: Can still be used in styled-components template literals, but the type has changed
- **Deprecated**: Use the `ButtonLink` component instead

### 3. `applyButtonVariantStyles` function
- **Old behavior**: Returned styled-components `FlattenSimpleInterpolation` type
- **New behavior**: Returns a plain CSS string
- **Impact**: Type incompatibility for consumers
- **Migration**: Can still be used in styled-components template literals
- **Deprecated**: Use `getButtonVariantStyles()` with CSS custom properties instead

## Non-Breaking Changes ✅

- All Button component props and behavior remain unchanged
- Visual appearance is identical to previous implementation
- All variants (Button, LinkButton, PlainButton, ButtonLink) maintain the same React API
- CSS custom properties include fallback defaults to prevent rendering issues

## Testing
- ✅ All unit tests passing (snapshots updated)
- ✅ Ladle build succeeds
- ✅ Visual appearance unchanged for all button variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1999]: https://openstax.atlassian.net/browse/CORE-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
