### PR TITLE
CORE-2001: Migrate uncontrolled form input components

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -7,13 +7,6 @@ const BannerContainer = styled.div`
   position: relative;
   padding-right: 2.5rem;
   width: 42rem;
-
-  svg {
-    position: absolute;
-    top: 1.7rem;
-    right: 1rem;
-    cursor: pointer;
-  }
 `;
 
 export const Error = () => (

--- a/src/components/forms/Forms.stories.tsx
+++ b/src/components/forms/Forms.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import {Controlled as Forms, Uncontrolled} from '.';
-import { fetchSuccess } from "@openstax/ts-utils/fetch";
+import { fetchSuccess, fetchError } from "@openstax/ts-utils/fetch";
 
 export const BasicControlledForm = () => {
   const data = {
@@ -118,4 +118,60 @@ export const DataReferencesInNamespaces = () => {
       </Forms.GetFormValue>
     </>}</Forms.GetFormData>
   </Forms.Form>
+};
+
+export const UncontrolledForm = () => {
+  const [submitted, setSubmitted] = React.useState<Record<string, any>>({});
+  const state = fetchSuccess({});
+
+  return <>
+    <h2>Basic Uncontrolled Form</h2>
+    <Uncontrolled.Form onSubmit={(e) => {
+      e.preventDefault();
+      const formData = new FormData(e.currentTarget);
+      const data = Object.fromEntries(formData.entries());
+      setSubmitted(data);
+    }}>
+      <Uncontrolled.FormSection>
+        <Uncontrolled.TextInput label="Name" name="name" help="Enter your full name" />
+        <Uncontrolled.TextInput label="Email" name="email" required help="We'll never share your email" />
+      </Uncontrolled.FormSection>
+      <Uncontrolled.Buttons state={state} />
+    </Uncontrolled.Form>
+    <pre>{JSON.stringify(submitted, null, 2)}</pre>
+  </>;
+};
+
+export const UncontrolledFormWithError = () => {
+  const errorState = fetchError('There was an error submitting the form');
+
+  return <>
+    <h2>Form with Error Message</h2>
+    <Uncontrolled.Form>
+      <Uncontrolled.Messages state={errorState} />
+      <Uncontrolled.TextInput label="Name" name="name" />
+      <Uncontrolled.Buttons state={errorState} onCancel={() => console.log('Cancelled')} />
+    </Uncontrolled.Form>
+  </>;
+};
+
+export const UncontrolledFormSections = () => {
+  const state = fetchSuccess({});
+
+  return <>
+    <h2>Form with Multiple Sections</h2>
+    <Uncontrolled.Form>
+      <Uncontrolled.FormSection>
+        <h3>Personal Information</h3>
+        <Uncontrolled.TextInput label="First Name" name="firstName" />
+        <Uncontrolled.TextInput label="Last Name" name="lastName" />
+      </Uncontrolled.FormSection>
+      <Uncontrolled.FormSection>
+        <h3>Contact Information</h3>
+        <Uncontrolled.TextInput label="Email" name="email" />
+        <Uncontrolled.TextInput label="Phone" name="phone" />
+      </Uncontrolled.FormSection>
+      <Uncontrolled.Buttons state={state} />
+    </Uncontrolled.Form>
+  </>;
 };

--- a/src/components/forms/uncontrolled/formComponents.css
+++ b/src/components/forms/uncontrolled/formComponents.css
@@ -1,0 +1,33 @@
+/* Form element styles */
+.form {
+  margin: 5px;
+}
+
+.form > *:not(:first-child) {
+  margin-top: 2rem;
+}
+
+.form h3 {
+  border-bottom: 1px solid var(--form-border-color, #ccc);
+}
+
+/* Form section styles */
+.form-section > *:not(:first-child) {
+  margin-top: 2rem;
+}
+
+/* Messages styles */
+.messages {
+  font-weight: bold;
+}
+
+/* Buttons container styles */
+.buttons {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.buttons {
+  margin-top: 3rem;
+}

--- a/src/components/forms/uncontrolled/formComponents.css
+++ b/src/components/forms/uncontrolled/formComponents.css
@@ -1,33 +1,30 @@
 /* Form element styles */
-.form {
+.uncontrolled-form {
   margin: 5px;
 }
 
-.form > *:not(:first-child) {
+.uncontrolled-form > *:not(:first-child) {
   margin-top: 2rem;
 }
 
-.form h3 {
-  border-bottom: 1px solid var(--form-border-color, #ccc);
+.uncontrolled-form h3 {
+  border-bottom: 1px solid #ccc;
 }
 
 /* Form section styles */
-.form-section > *:not(:first-child) {
+.uncontrolled-form-section > *:not(:first-child) {
   margin-top: 2rem;
 }
 
 /* Messages styles */
-.messages {
+.uncontrolled-messages {
   font-weight: bold;
 }
 
 /* Buttons container styles */
-.buttons {
+.uncontrolled-buttons {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-}
-
-.buttons {
   margin-top: 3rem;
 }

--- a/src/components/forms/uncontrolled/index.tsx
+++ b/src/components/forms/uncontrolled/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
 import { stateHasError, FetchState } from "@openstax/ts-utils/fetch";
+import './formComponents.css';
 
 export * from './inputs';
 
@@ -8,35 +8,30 @@ export * from './inputs';
  * form element
  */
 type FormProps = React.ComponentPropsWithoutRef<'form'>;
-export const Form = styled(({children, ...props}: FormProps) => <form {...props}>
-  {children}
-</form>)`
-  margin: 5px;
-  > *:not(:first-child) {
-    margin-top: 2rem;
-  }
+export const Form = ({children, className, style, ...props}: FormProps) => {
+  const formStyle = {
+    '--form-border-color': '#ccc',
+    ...style
+  } as React.CSSProperties;
 
-  h3 {
-    border-bottom: 1px solid #ccc;
-  }
-`;
+  return (
+    <form className={`form ${className || ''}`} style={formStyle} {...props}>
+      {children}
+    </form>
+  );
+};
 
-export const FormSection = styled.div`
-  > *:not(:first-child) {
-    margin-top: 2rem;
-  }
-`;
+export const FormSection = ({className, ...props}: React.ComponentPropsWithoutRef<'div'>) => (
+  <div className={`form-section ${className || ''}`} {...props} />
+);
 
 type MessagesProps = {
   state: FetchState<any, string>;
   className?: string;
 };
-export const Messages = styled(({state}: MessagesProps) => stateHasError(state)
-  ? <div>{state.error}</div>
-  : null
-)`
-  font-weight: bold;
-`;
+export const Messages = ({state, className}: MessagesProps) => stateHasError(state)
+  ? <div className={`messages ${className || ''}`}>{state.error}</div>
+  : null;
 
 /*
  * form buttons
@@ -46,26 +41,18 @@ type ButtonsProps = {
   onCancel?: () => void;
   className?: string;
 };
-export const Buttons = styled((props: ButtonsProps) => <div className={props.className}>
-  {'onCancel' in props ? <Cancel onClick={props.onCancel}>Cancel</Cancel> : null}
-  <Submit />
-</div>)`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  && {
-    margin-top: 3rem;
-  }
-`;
+export const Buttons = (props: ButtonsProps) => (
+  <div className={`buttons ${props.className || ''}`}>
+    {'onCancel' in props ? <Cancel onClick={props.onCancel}>Cancel</Cancel> : null}
+    <Submit />
+  </div>
+);
 
 // submit button
 type SubmitButtonProps = React.ComponentPropsWithoutRef<'input'>;
-export const Submit = styled(({...props}: SubmitButtonProps) =>
-  <input type="submit" value="Submit" {...props} />
-)`
-`;
+export const Submit = ({...props}: SubmitButtonProps) =>
+  <input type="submit" value="Submit" {...props} />;
 
 // cancel button
 type CancelButtonProps = React.ComponentPropsWithoutRef<'button'>;
-export const Cancel = styled(({...props}: CancelButtonProps) => <button type="button" {...props} />)`
-`;
+export const Cancel = ({...props}: CancelButtonProps) => <button type="button" {...props} />;

--- a/src/components/forms/uncontrolled/index.tsx
+++ b/src/components/forms/uncontrolled/index.tsx
@@ -9,20 +9,15 @@ export * from './inputs';
  */
 type FormProps = React.ComponentPropsWithoutRef<'form'>;
 export const Form = ({children, className, style, ...props}: FormProps) => {
-  const formStyle = {
-    '--form-border-color': '#ccc',
-    ...style
-  } as React.CSSProperties;
-
   return (
-    <form className={`form ${className || ''}`} style={formStyle} {...props}>
+    <form className={`uncontrolled-form ${className || ''}`} style={style} {...props}>
       {children}
     </form>
   );
 };
 
 export const FormSection = ({className, ...props}: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={`form-section ${className || ''}`} {...props} />
+  <div className={`uncontrolled-form-section ${className || ''}`} {...props} />
 );
 
 type MessagesProps = {
@@ -30,7 +25,7 @@ type MessagesProps = {
   className?: string;
 };
 export const Messages = ({state, className}: MessagesProps) => stateHasError(state)
-  ? <div className={`messages ${className || ''}`}>{state.error}</div>
+  ? <div className={`uncontrolled-messages ${className || ''}`}>{state.error}</div>
   : null;
 
 /*
@@ -42,7 +37,7 @@ type ButtonsProps = {
   className?: string;
 };
 export const Buttons = (props: ButtonsProps) => (
-  <div className={`buttons ${props.className || ''}`}>
+  <div className={`uncontrolled-buttons ${props.className || ''}`}>
     {'onCancel' in props ? <Cancel onClick={props.onCancel}>Cancel</Cancel> : null}
     <Submit />
   </div>

--- a/src/components/forms/uncontrolled/inputDecorations.css
+++ b/src/components/forms/uncontrolled/inputDecorations.css
@@ -1,5 +1,5 @@
 /* Form input wrapper label styles */
-.form-input-wrapper {
+.uncontrolled-form-input-wrapper {
   display: flex;
   flex-direction: column;
   flex: 0;
@@ -7,14 +7,14 @@
 }
 
 /* Form label text styles */
-.form-label-text {
+.uncontrolled-form-label-text {
   white-space: nowrap;
   font-weight: bold;
   display: block;
 }
 
 /* Help text styles */
-.help-text {
+.uncontrolled-help-text {
   font-style: italic;
   margin: 0;
   padding: 0;

--- a/src/components/forms/uncontrolled/inputDecorations.css
+++ b/src/components/forms/uncontrolled/inputDecorations.css
@@ -1,0 +1,21 @@
+/* Form input wrapper label styles */
+.form-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  flex: 0;
+  justify-content: stretch;
+}
+
+/* Form label text styles */
+.form-label-text {
+  white-space: nowrap;
+  font-weight: bold;
+  display: block;
+}
+
+/* Help text styles */
+.help-text {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+}

--- a/src/components/forms/uncontrolled/inputDecorations.tsx
+++ b/src/components/forms/uncontrolled/inputDecorations.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
+import classNames from 'classnames';
 import './inputDecorations.css';
 
 export const FormInputWrapper = React.forwardRef<
   HTMLLabelElement,
   React.ComponentPropsWithoutRef<'label'>
 >(({className, ...props}, ref) => (
-  <label ref={ref} className={`form-input-wrapper ${className || ''}`} {...props} />
+  <label ref={ref} className={classNames('uncontrolled-form-input-wrapper', className)} {...props} />
 ));
 FormInputWrapper.displayName = 'FormInputWrapper';
 
 export const FormLabelText = ({className, ...props}: React.ComponentPropsWithoutRef<'span'>) => (
-  <span className={`form-label-text ${className || ''}`} {...props} />
+  <span className={classNames('uncontrolled-form-label-text', className)} {...props} />
 );
 
 export type InputProps = {
@@ -25,7 +26,7 @@ type HelpTextProps = React.ComponentPropsWithoutRef<'p'> & {
   value: string | undefined | React.ReactNode;
 };
 export const HelpText = ({value, className, ...props}: HelpTextProps) => value
-  ? <p className={`help-text ${className || ''}`} {...props}>{value}</p>
+  ? <p className={classNames('uncontrolled-help-text', className)} {...props}>{value}</p>
   : null;
 
 export const RequiredIndicator = (props: {show: boolean | undefined}) => props.show ? <>*</> : null;

--- a/src/components/forms/uncontrolled/inputDecorations.tsx
+++ b/src/components/forms/uncontrolled/inputDecorations.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import styled from 'styled-components';
+import './inputDecorations.css';
 
-export const FormInputWrapper = styled.label`
-  display: flex;
-  flex-direction: column;
-  flex: 0;
-  justify-content: stretch;
-`;
+export const FormInputWrapper = React.forwardRef<
+  HTMLLabelElement,
+  React.ComponentPropsWithoutRef<'label'>
+>(({className, ...props}, ref) => (
+  <label ref={ref} className={`form-input-wrapper ${className || ''}`} {...props} />
+));
+FormInputWrapper.displayName = 'FormInputWrapper';
 
-export const FormLabelText = styled.span`
-  white-space: nowrap;
-  font-weight: bold;
-  display: block;
-`;
+export const FormLabelText = ({className, ...props}: React.ComponentPropsWithoutRef<'span'>) => (
+  <span className={`form-label-text ${className || ''}`} {...props} />
+);
 
 export type InputProps = {
   label: string;
@@ -22,16 +21,11 @@ export type InputProps = {
 /*
  * help text
  */
-const HelpTextElement = styled.p`
-  font-style: italic;
-  margin: 0;
-  padding: 0;
-`;
 type HelpTextProps = React.ComponentPropsWithoutRef<'p'> & {
   value: string | undefined | React.ReactNode;
 };
-export const HelpText = ({value, ...props}: HelpTextProps) => value
-  ? <HelpTextElement {...props}>{value}</HelpTextElement>
+export const HelpText = ({value, className, ...props}: HelpTextProps) => value
+  ? <p className={`help-text ${className || ''}`} {...props}>{value}</p>
   : null;
 
 export const RequiredIndicator = (props: {show: boolean | undefined}) => props.show ? <>*</> : null;

--- a/src/components/forms/uncontrolled/inputType.stories.tsx
+++ b/src/components/forms/uncontrolled/inputType.stories.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Checkbox, RangeInput } from "./inputTypes";
+import { Checkbox, RangeInput, TextInput, TextArea, Select, Radio, File } from "./inputTypes";
 
 
 const CheckboxGroup = styled.div`
@@ -46,4 +46,73 @@ export const slider = () => <>
   <RangeInput min={0} max={100} defaultValue={50} label="Label" name="name" help="Help text"
     labels={[{value: 0, label: '0%'}, {value: 50, label: '50%'}, {value: 100, label: '100%'}]}
   />
+</>;
+
+export const textInput = () => <>
+  <h2>Basic TextInput</h2>
+  <TextInput label="Name" name="name" placeholder="Enter your name" />
+  <h2>TextInput with Help Text</h2>
+  <TextInput label="Email" name="email" placeholder="email@example.com" help="We'll never share your email" />
+  <h2>Required TextInput</h2>
+  <TextInput label="Username" name="username" required placeholder="Choose a username" />
+  <h2>TextInput with Addon</h2>
+  <TextInput label="Website" name="website" placeholder="example.com" addon={<span>https://</span>} />
+</>;
+
+export const textArea = () => <>
+  <h2>Basic TextArea</h2>
+  <TextArea label="Comments" name="comments" placeholder="Enter your comments" />
+  <h2>TextArea with Help Text</h2>
+  <TextArea label="Description" name="description" help="Please provide a detailed description" />
+  <h2>Required TextArea</h2>
+  <TextArea label="Feedback" name="feedback" required placeholder="Your feedback is important to us" />
+</>;
+
+export const selectInput = () => <>
+  <h2>Basic Select</h2>
+  <Select label="Country" name="country" options={[
+    {label: 'United States', value: 'us'},
+    {label: 'Canada', value: 'ca'},
+    {label: 'Mexico', value: 'mx'}
+  ]} />
+  <h2>Select with Help Text</h2>
+  <Select label="State" name="state" help="Select your state of residence" options={[
+    {label: 'California', value: 'ca'},
+    {label: 'Texas', value: 'tx'},
+    {label: 'New York', value: 'ny'}
+  ]} />
+  <h2>Required Select</h2>
+  <Select label="Department" name="department" required options={[
+    {label: 'Engineering', value: 'eng'},
+    {label: 'Sales', value: 'sales'},
+    {label: 'Marketing', value: 'marketing'}
+  ]} />
+  <h2>Select with Groups</h2>
+  <Select label="Product" name="product" options={[
+    {label: 'Biology', value: 'bio', group: 'Science'},
+    {label: 'Chemistry', value: 'chem', group: 'Science'},
+    {label: 'History', value: 'hist', group: 'Humanities'},
+    {label: 'Literature', value: 'lit', group: 'Humanities'}
+  ]} />
+</>;
+
+export const radioInput = () => <>
+  <h2>Basic Radio</h2>
+  <Radio label="Option 1" name="choice" value="1" />
+  <Radio label="Option 2" name="choice" value="2" />
+  <Radio label="Option 3" name="choice" value="3" />
+  <h2>Radio with Help Text</h2>
+  <Radio label="Yes" name="agreement" value="yes" help="I agree to the terms" />
+  <Radio label="No" name="agreement" value="no" help="I do not agree" />
+  <h2>Required Radio</h2>
+  <Radio label="Required Option" name="required" value="req" required />
+</>;
+
+export const fileInput = () => <>
+  <h2>Basic File Input</h2>
+  <File label="Upload Document" name="document" />
+  <h2>File Input with Help Text</h2>
+  <File label="Profile Picture" name="avatar" help="Please upload a JPG or PNG file" accept="image/jpeg,image/png" />
+  <h2>Multiple Files</h2>
+  <File label="Attachments" name="attachments" multiple help="You can select multiple files" />
 </>;

--- a/src/components/forms/uncontrolled/inputTypes.css
+++ b/src/components/forms/uncontrolled/inputTypes.css
@@ -1,0 +1,62 @@
+/* Input element styles */
+.input-element {
+  flex: 1;
+  justify-content: stretch;
+}
+
+/* Flex row container */
+.flex-row {
+  flex-direction: row;
+  display: flex;
+}
+
+/* Radio line styles */
+.radio-line {
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+}
+
+/* Radio form label text (with normal white-space) */
+.radio-form-label-text {
+  white-space: normal;
+}
+
+/* Checkbox line styles */
+.checkbox-line {
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+}
+
+/* Error message styles */
+.error-message {
+  color: var(--error-color, #C22032);
+  font-size: 1.6rem;
+  margin: 0;
+  padding: 0;
+  line-height: 2.5rem;
+}
+
+/* Range input wrapper styles (extends form-input-wrapper) */
+.range-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  flex: 0;
+  justify-content: stretch;
+}
+
+.range-input-wrapper datalist {
+  display: flex;
+  justify-content: space-between;
+  writing-mode: unset;
+  flex-direction: row;
+  padding: 0 1em;
+}
+
+.range-input-wrapper datalist option {
+  width: 0;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/forms/uncontrolled/inputTypes.css
+++ b/src/components/forms/uncontrolled/inputTypes.css
@@ -1,52 +1,45 @@
 /* Input element styles */
-.input-element {
+.uncontrolled-input-element {
   flex: 1;
   justify-content: stretch;
 }
 
 /* Flex row container */
-.flex-row {
+.uncontrolled-flex-row {
   flex-direction: row;
   display: flex;
 }
 
 /* Radio line styles */
-.radio-line {
+.uncontrolled-radio-line {
   flex-direction: row;
   display: flex;
   align-items: center;
 }
 
 /* Radio form label text (with normal white-space) */
-.radio-form-label-text {
+.uncontrolled-radio-form-label-text {
   white-space: normal;
 }
 
 /* Checkbox line styles */
-.checkbox-line {
+.uncontrolled-checkbox-line {
   flex-direction: row;
   display: flex;
   align-items: center;
 }
 
 /* Error message styles */
-.error-message {
-  color: var(--error-color, #C22032);
+.uncontrolled-error-message {
+  color: #C22032;
   font-size: 1.6rem;
   margin: 0;
   padding: 0;
   line-height: 2.5rem;
 }
 
-/* Range input wrapper styles (extends form-input-wrapper) */
-.range-input-wrapper {
-  display: flex;
-  flex-direction: column;
-  flex: 0;
-  justify-content: stretch;
-}
-
-.range-input-wrapper datalist {
+/* Range input wrapper styles (extends form-input-wrapper via FormInputWrapper component) */
+.uncontrolled-range-input-wrapper datalist {
   display: flex;
   justify-content: space-between;
   writing-mode: unset;
@@ -54,7 +47,7 @@
   padding: 0 1em;
 }
 
-.range-input-wrapper datalist option {
+.uncontrolled-range-input-wrapper datalist option {
   width: 0;
   text-align: center;
   display: flex;

--- a/src/components/forms/uncontrolled/inputTypes.tsx
+++ b/src/components/forms/uncontrolled/inputTypes.tsx
@@ -4,6 +4,7 @@ import { AbstractFormData } from "../controlled/hooks";
 import { partitionSequence } from "@openstax/ts-utils/misc/partitionSequence";
 import { Radio as StyledRadio } from "../../Radio";
 import { Checkbox as StyledCheckbox } from "../../Checkbox/Checkbox";
+import classNames from 'classnames';
 import './inputTypes.css';
 type TextInputProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
   wrapperProps?: React.ComponentPropsWithoutRef<'label'>;
@@ -13,12 +14,12 @@ type TextInputProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
   pattern?: string;
 };
 export const TextInput = ({
-  label, addon, help, transformValue, wrapperProps, onChangeValue, ...props
+  label, addon, help, transformValue, wrapperProps, onChangeValue, className, ...props
 }: TextInputProps) =>
   <FormInputWrapper {...wrapperProps}>
     <FormLabelText><RequiredIndicator show={props.required} />{label}:</FormLabelText>
-    <div className="flex-row">
-      <input className="input-element" type="text" {...props} onChange={e => {
+    <div className="uncontrolled-flex-row">
+      <input type="text" {...props} className={classNames("uncontrolled-input-element", className)} onChange={e => {
         onChangeValue?.(transformValue ? transformValue(e.target.value) : e.target.value);
         props.onChange?.(e);
       }} />
@@ -161,14 +162,14 @@ export const Radio = ({
   ...props
 }: RadioProps) => {
   return <FormInputWrapper {...wrapperProps}>
-    <div className="radio-line">
+    <div className="uncontrolled-radio-line">
       <StyledRadio {...props} labelAs="div" onChange={e => {
         if (e.target.checked) {
           onChangeValue?.(e.target.value);
         }
         props.onChange?.(e);
       }}>
-        <FormLabelText className="radio-form-label-text"><RequiredIndicator show={props.required} />{label}</FormLabelText>
+        <FormLabelText className="uncontrolled-radio-form-label-text"><RequiredIndicator show={props.required} />{label}</FormLabelText>
       </StyledRadio>
     </div>
     <HelpText value={help} />
@@ -192,12 +193,8 @@ export const Checkbox = ({
   onChangeValue,
   ...props
 }: CheckboxProps) => {
-  const errorStyle = {
-    '--error-color': '#C22032'
-  } as React.CSSProperties;
-
   return <FormInputWrapper {...wrapperProps}>
-    <div className="checkbox-line">
+    <div className="uncontrolled-checkbox-line">
       <StyledCheckbox {...props} onChange={e => {
         onChangeValue?.(!!e.target.checked);
         props.onChange?.(e);
@@ -210,7 +207,7 @@ export const Checkbox = ({
     {error !== undefined && (
         <>
           {error.map((msg, i) => (
-            <p key={i} className="error-message" style={errorStyle}>{msg}</p>
+            <p key={i} className="uncontrolled-error-message">{msg}</p>
           ))}
         </>
       )}
@@ -254,7 +251,7 @@ type RangeProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
 export const RangeInput = ({label, help, wrapperProps, onChangeValue, labels, ...props}: RangeProps) => {
   const datalistId = React.useMemo(() => `datalist-${Math.random().toString(36).substring(2, 15)}`, []);
 
-  return <label {...wrapperProps} className={`range-input-wrapper ${wrapperProps?.className || ''}`}>
+  return <FormInputWrapper {...wrapperProps} className={`uncontrolled-range-input-wrapper ${wrapperProps?.className || ''}`}>
     <FormLabelText><RequiredIndicator show={props.required} />{label}:</FormLabelText>
     <input type="range" {...props}
       list={labels && labels.length > 0 ? datalistId : undefined}
@@ -272,5 +269,5 @@ export const RangeInput = ({label, help, wrapperProps, onChangeValue, labels, ..
       </datalist>
     )}
     <HelpText value={help} />
-  </label>;
+  </FormInputWrapper>;
 }

--- a/src/components/forms/uncontrolled/inputTypes.tsx
+++ b/src/components/forms/uncontrolled/inputTypes.tsx
@@ -1,22 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
 import { FormInputWrapper, FormLabelText, HelpText, InputProps, RequiredIndicator } from "./inputDecorations";
 import { AbstractFormData } from "../controlled/hooks";
 import { partitionSequence } from "@openstax/ts-utils/misc/partitionSequence";
 import { Radio as StyledRadio } from "../../Radio";
-import { Checkbox as StyledCheckbox } from "../../Checkbox/Checkbox"
-
-/*
- * input element
- */
-const InputElement = styled.input`
-  flex: 1;
-  justify-content: stretch;
-`;
-const FlexRow = styled.div`
-  flex-direction: row;
-  display: flex;
-`;
+import { Checkbox as StyledCheckbox } from "../../Checkbox/Checkbox";
+import './inputTypes.css';
 type TextInputProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
   wrapperProps?: React.ComponentPropsWithoutRef<'label'>;
   onChangeValue?: (value: any) => void;
@@ -29,13 +17,13 @@ export const TextInput = ({
 }: TextInputProps) =>
   <FormInputWrapper {...wrapperProps}>
     <FormLabelText><RequiredIndicator show={props.required} />{label}:</FormLabelText>
-    <FlexRow>
-      <InputElement type="text" {...props} onChange={e => {
+    <div className="flex-row">
+      <input className="input-element" type="text" {...props} onChange={e => {
         onChangeValue?.(transformValue ? transformValue(e.target.value) : e.target.value);
         props.onChange?.(e);
       }} />
       {addon}
-    </FlexRow>
+    </div>
     <HelpText value={help} />
   </FormInputWrapper>;
 
@@ -165,14 +153,6 @@ type RadioProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
   wrapperProps?: React.ComponentPropsWithoutRef<'label'>;
   tooltipText?: string;
 };
-const RadioLine = styled.div`
-  flex-direction: row;
-  display: flex;
-  align-items: center;
-`;
-const RadioFormLabelText = styled(FormLabelText)`
-  white-space: normal;
-`;
 export const Radio = ({
   label,
   help,
@@ -181,16 +161,16 @@ export const Radio = ({
   ...props
 }: RadioProps) => {
   return <FormInputWrapper {...wrapperProps}>
-    <RadioLine>
+    <div className="radio-line">
       <StyledRadio {...props} labelAs="div" onChange={e => {
         if (e.target.checked) {
           onChangeValue?.(e.target.value);
         }
         props.onChange?.(e);
       }}>
-        <RadioFormLabelText><RequiredIndicator show={props.required} />{label}</RadioFormLabelText>
+        <FormLabelText className="radio-form-label-text"><RequiredIndicator show={props.required} />{label}</FormLabelText>
       </StyledRadio>
-    </RadioLine>
+    </div>
     <HelpText value={help} />
   </FormInputWrapper>;
 };
@@ -204,18 +184,6 @@ Parameters<typeof StyledCheckbox>[0] & {
   wrapperProps?: React.ComponentPropsWithoutRef<'label'>;
   error?: string[];
 };
-const CheckboxLine = styled.div`
-  flex-direction: row;
-  display: flex;
-  align-items: center;
-`;
-const StyledErrorMessage = styled.p`
-  color: #C22032;
-  font-size: 1.6rem;
-  margin: 0;
-  padding: 0;
-  line-height: 2.5rem;
-`
 export const Checkbox = ({
   label,
   help,
@@ -224,8 +192,12 @@ export const Checkbox = ({
   onChangeValue,
   ...props
 }: CheckboxProps) => {
+  const errorStyle = {
+    '--error-color': '#C22032'
+  } as React.CSSProperties;
+
   return <FormInputWrapper {...wrapperProps}>
-    <CheckboxLine>
+    <div className="checkbox-line">
       <StyledCheckbox {...props} onChange={e => {
         onChangeValue?.(!!e.target.checked);
         props.onChange?.(e);
@@ -233,12 +205,12 @@ export const Checkbox = ({
       >
         <FormLabelText><RequiredIndicator show={props.required} />{label}</FormLabelText>
       </StyledCheckbox>
-    </CheckboxLine>
+    </div>
     <HelpText value={help} />
     {error !== undefined && (
         <>
           {error.map((msg, i) => (
-            <StyledErrorMessage key={i}>{msg}</StyledErrorMessage>
+            <p key={i} className="error-message" style={errorStyle}>{msg}</p>
           ))}
         </>
       )}
@@ -274,22 +246,6 @@ export const File = ({label, help, wrapperProps, onChangeValue, uploader, value,
   </FormInputWrapper>;
 };
 
-const RangeInputWrapper = styled(FormInputWrapper)`
-  datalist {
-    display: flex;
-    justify-content: space-between;
-    writing-mode:unset;
-    flex-direction: row;
-    padding: 0 1em;
-
-    option {
-      width: 0;
-      text-align: center;
-      display: flex;
-      justify-content: center;
-    }
-  }
-`;
 type RangeProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
   wrapperProps?: React.ComponentPropsWithoutRef<'label'>;
   onChangeValue?: (value: number | undefined) => void;
@@ -298,7 +254,7 @@ type RangeProps = React.ComponentPropsWithoutRef<'input'> & InputProps & {
 export const RangeInput = ({label, help, wrapperProps, onChangeValue, labels, ...props}: RangeProps) => {
   const datalistId = React.useMemo(() => `datalist-${Math.random().toString(36).substring(2, 15)}`, []);
 
-  return <RangeInputWrapper {...wrapperProps}>
+  return <label {...wrapperProps} className={`range-input-wrapper ${wrapperProps?.className || ''}`}>
     <FormLabelText><RequiredIndicator show={props.required} />{label}:</FormLabelText>
     <input type="range" {...props}
       list={labels && labels.length > 0 ? datalistId : undefined}
@@ -316,5 +272,5 @@ export const RangeInput = ({label, help, wrapperProps, onChangeValue, labels, ..
       </datalist>
     )}
     <HelpText value={help} />
-  </RangeInputWrapper>;
+  </label>;
 }


### PR DESCRIPTION
## Summary

This PR migrates the uncontrolled form input components from styled-components to plain CSS, following the same pattern as CORE-2000 (Checkbox and Radio migration).

### Components migrated:
- `inputDecorations.tsx` - FormInputWrapper, FormLabelText, HelpText
- `inputTypes.tsx` - TextInput, TextArea, Select, Radio, Checkbox, File, RangeInput
- `index.tsx` - Form, FormSection, Messages, Buttons, Submit, Cancel

### Changes:
- ✅ Created three CSS files: `inputDecorations.css`, `inputTypes.css`, `formComponents.css`
- ✅ Converted all styled-components to plain HTML elements with CSS classes
- ✅ Preserved all existing props and functionality
- ✅ Maintained compatibility with existing Checkbox and Radio components

### Related:
- Jira: [CORE-2001](https://openstax.atlassian.net/browse/CORE-2001)
- Depends on: #120 (CORE-2000) - Should be tested after that merges to ensure compatibility

### Testing:
The CI will run tests to verify:
- All existing tests pass
- Ladle stories render correctly
- All input types work as expected
- Components maintain their visual appearance and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2001]: https://openstax.atlassian.net/browse/CORE-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ