### PR TITLE
CORE-2004: Migrate NavBar components to plain CSS

### DIFF
--- a/src/components/BodyPortal.spec.tsx
+++ b/src/components/BodyPortal.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { CSSPropertiesWithVariables } from '../types';
 import { render } from '@testing-library/react';
 import { BodyPortal } from './BodyPortal';
 import { BodyPortalSlotsContext } from './BodyPortalSlotsContext';
@@ -266,7 +267,7 @@ describe('BodyPortal', () => {
     render(
       <BodyPortal
         slot='modal'
-        style={{ '--my-variable': 'red', '--another-var': '10px' } as React.CSSProperties}
+        style={{ '--my-variable': 'red', '--another-var': '10px' } as CSSPropertiesWithVariables}
       >
         Modal content
       </BodyPortal>,
@@ -300,7 +301,7 @@ describe('BodyPortal', () => {
     const TestComponent = ({ color }: { color: string }) => (
       <BodyPortal
         slot='modal'
-        style={{ '--color': color } as React.CSSProperties}
+        style={{ '--color': color } as CSSPropertiesWithVariables}
       >
         Modal content
       </BodyPortal>
@@ -326,7 +327,7 @@ describe('BodyPortal', () => {
     const { unmount } = render(
       <BodyPortal
         slot='modal'
-        style={{ '--my-variable': 'red', backgroundColor: 'blue' } as React.CSSProperties}
+        style={{ '--my-variable': 'red', backgroundColor: 'blue' } as CSSPropertiesWithVariables}
       >
         Modal content
       </BodyPortal>,
@@ -344,11 +345,11 @@ describe('BodyPortal', () => {
     expect(document.body.querySelector('[data-portal-slot="modal"]')).toBeNull();
   });
 
-  it('handles null and undefined style values gracefully', () => {
+  it('handles undefined style values gracefully', () => {
     render(
       <BodyPortal
         slot='modal'
-        style={{ '--defined': 'red', '--null': null, '--undefined': undefined } as React.CSSProperties}
+        style={{ '--defined': 'red', '--undefined': undefined } as CSSPropertiesWithVariables}
       >
         Modal content
       </BodyPortal>,
@@ -359,7 +360,6 @@ describe('BodyPortal', () => {
     expect(portal).toBeTruthy();
     expect(portal.style.getPropertyValue('--defined')).toBe('red');
     // null and undefined values should not be set
-    expect(portal.style.getPropertyValue('--null')).toBe('');
     expect(portal.style.getPropertyValue('--undefined')).toBe('');
   });
 });

--- a/src/components/BodyPortal.spec.tsx
+++ b/src/components/BodyPortal.spec.tsx
@@ -261,4 +261,105 @@ describe('BodyPortal', () => {
 </body>
 `);
   });
+
+  it('applies CSS variables from style prop', () => {
+    render(
+      <BodyPortal
+        slot='modal'
+        style={{ '--my-variable': 'red', '--another-var': '10px' } as React.CSSProperties}
+      >
+        Modal content
+      </BodyPortal>,
+      { container: root }
+    );
+
+    const portal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(portal).toBeTruthy();
+    expect(portal.style.getPropertyValue('--my-variable')).toBe('red');
+    expect(portal.style.getPropertyValue('--another-var')).toBe('10px');
+  });
+
+  it('applies regular CSS properties from style prop', () => {
+    render(
+      <BodyPortal
+        slot='modal'
+        style={{ backgroundColor: 'blue', fontSize: '16px' }}
+      >
+        Modal content
+      </BodyPortal>,
+      { container: root }
+    );
+
+    const portal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(portal).toBeTruthy();
+    expect(portal.style.backgroundColor).toBe('blue');
+    expect(portal.style.fontSize).toBe('16px');
+  });
+
+  it('updates styles when style prop changes without removing portal element', () => {
+    const TestComponent = ({ color }: { color: string }) => (
+      <BodyPortal
+        slot='modal'
+        style={{ '--color': color } as React.CSSProperties}
+      >
+        Modal content
+      </BodyPortal>
+    );
+
+    const { rerender } = render(<TestComponent color='red' />, { container: root });
+
+    const portal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(portal).toBeTruthy();
+    expect(portal.style.getPropertyValue('--color')).toBe('red');
+
+    // Store reference to verify it's the same element after update
+    const portalRef = portal;
+
+    rerender(<TestComponent color='blue' />);
+
+    const updatedPortal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(updatedPortal).toBe(portalRef); // Should be the same element
+    expect(updatedPortal.style.getPropertyValue('--color')).toBe('blue');
+  });
+
+  it('removes styles on unmount', () => {
+    const { unmount } = render(
+      <BodyPortal
+        slot='modal'
+        style={{ '--my-variable': 'red', backgroundColor: 'blue' } as React.CSSProperties}
+      >
+        Modal content
+      </BodyPortal>,
+      { container: root }
+    );
+
+    const portal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(portal).toBeTruthy();
+    expect(portal.style.getPropertyValue('--my-variable')).toBe('red');
+    expect(portal.style.backgroundColor).toBe('blue');
+
+    unmount();
+
+    // Portal element should be removed from DOM
+    expect(document.body.querySelector('[data-portal-slot="modal"]')).toBeNull();
+  });
+
+  it('handles null and undefined style values gracefully', () => {
+    render(
+      <BodyPortal
+        slot='modal'
+        style={{ '--defined': 'red', '--null': null, '--undefined': undefined } as React.CSSProperties}
+      >
+        Modal content
+      </BodyPortal>,
+      { container: root }
+    );
+
+    const portal = document.body.querySelector('[data-portal-slot="modal"]') as HTMLElement;
+    expect(portal).toBeTruthy();
+    expect(portal.style.getPropertyValue('--defined')).toBe('red');
+    // null and undefined values should not be set
+    expect(portal.style.getPropertyValue('--null')).toBe('');
+    expect(portal.style.getPropertyValue('--undefined')).toBe('');
+  });
 });

--- a/src/components/BodyPortal.tsx
+++ b/src/components/BodyPortal.tsx
@@ -99,19 +99,24 @@ export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((
     // Apply styles
     Object.entries(style).forEach(([key, value]) => {
       if (value == null) return;
-      const cssKey = key.startsWith('--') ? key : key.replace(/([A-Z])/g, '-$1').toLowerCase();
-      element.style.setProperty(cssKey, String(value));
-    });
+      if (key.startsWith('--')) {
+        element.style.setProperty(key, String(value));
+      } else {
+        // Use camelCased style keys (e.g. cssFloat) directly instead of converting to kebab-case.
+        (element.style as any)[key] = value as any;
+      }    });
 
     // Cleanup: remove styles on unmount or when style prop changes
     return () => {
-      Object.keys(style).forEach(key => {
-        // Convert camelCase to kebab-case for CSS property names
-        const cssKey = key.startsWith('--') ? key : key.replace(/([A-Z])/g, '-$1').toLowerCase();
-        element.style.removeProperty(cssKey);
+      Object.keys(style).forEach((key) => {
+        if (key.startsWith('--')) {
+          element.style.removeProperty(key);
+        } else {
+          (element.style as any)[key] = '';
+        }
       });
     };
-  }, [style]);
+  }, [style, tag]);
 
   if (!internalRef.current) { return null; }
 

--- a/src/components/BodyPortal.tsx
+++ b/src/components/BodyPortal.tsx
@@ -105,7 +105,8 @@ export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((
       } else {
         // Use camelCased style keys (e.g. cssFloat) directly instead of converting to kebab-case.
         (element.style as any)[key] = value as any;
-      }    });
+      }
+    });
 
     // Cleanup: remove styles on unmount or when style prop changes
     return () => {

--- a/src/components/BodyPortal.tsx
+++ b/src/components/BodyPortal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { BodyPortalSlotsContext } from './BodyPortalSlotsContext';
+import { CSSPropertiesWithVariables } from '../types';
 
 const getInsertBeforeTarget = (bodyPortalSlots: string[], slot?: string) => {
   // Note: If the slot is not found in bodyPortalSlots, this code will append the tag instead,
@@ -29,7 +30,7 @@ export type BodyPortalProps = React.PropsWithChildren<{
   id?: string;
   'data-testid'?: string;
   ariaLabel?: string;
-  style?: React.CSSProperties;
+  style?: CSSPropertiesWithVariables;
 }>;
 
 export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((

--- a/src/components/BodyPortal.tsx
+++ b/src/components/BodyPortal.tsx
@@ -29,10 +29,11 @@ export type BodyPortalProps = React.PropsWithChildren<{
   id?: string;
   'data-testid'?: string;
   ariaLabel?: string;
+  style?: React.CSSProperties;
 }>;
 
 export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((
-  { children, className, role, slot, tagName, id, ariaLabel, ...props }, ref?: React.ForwardedRef<HTMLElement>
+  { children, className, role, slot, tagName, id, ariaLabel, style, ...props }, ref?: React.ForwardedRef<HTMLElement>
 ) => {
   const tag = tagName?.toUpperCase() ?? 'DIV';
   const internalRef = React.useRef<HTMLElement | null>(
@@ -52,6 +53,7 @@ export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((
   const bodyPortalOrderedRefs = React.useContext(BodyPortalSlotsContext);
   const testId = props['data-testid'];
 
+  // Effect for creating/destroying the portal element and setting non-style props
   React.useLayoutEffect(() => {
     const element = internalRef.current;
     if (!element) { return; }
@@ -88,6 +90,28 @@ export const BodyPortal = React.forwardRef<HTMLElement, BodyPortalProps>((
       if (testId) { delete element.dataset.testid; }
     };
   }, [bodyPortalOrderedRefs, className, id, role, slot, ariaLabel, tag, testId]);
+
+  // Separate effect for updating styles without removing/reinserting the portal
+  React.useLayoutEffect(() => {
+    const element = internalRef.current;
+    if (!element || !style) { return; }
+
+    // Apply styles
+    Object.entries(style).forEach(([key, value]) => {
+      if (value == null) return;
+      const cssKey = key.startsWith('--') ? key : key.replace(/([A-Z])/g, '-$1').toLowerCase();
+      element.style.setProperty(cssKey, String(value));
+    });
+
+    // Cleanup: remove styles on unmount or when style prop changes
+    return () => {
+      Object.keys(style).forEach(key => {
+        // Convert camelCase to kebab-case for CSS property names
+        const cssKey = key.startsWith('--') ? key : key.replace(/([A-Z])/g, '-$1').toLowerCase();
+        element.style.removeProperty(cssKey);
+      });
+    };
+  }, [style]);
 
   if (!internalRef.current) { return null; }
 

--- a/src/components/HelpMenu/__snapshots__/index.spec.tsx.snap
+++ b/src/components/HelpMenu/__snapshots__/index.spec.tsx.snap
@@ -4,11 +4,13 @@ exports[`HelpMenu matches snapshot 1`] = `
 <body>
   <nav
     aria-hidden="true"
-    class="sc-papXJ kjJxrB"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-jqUVSM exKmPA"
+      class="navbar-bar"
+      style="--navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       <svg
         class="navbar-logo"
@@ -55,7 +57,7 @@ exports[`HelpMenu matches snapshot 1`] = `
         aria-expanded="true"
         aria-haspopup="true"
         aria-label="Help menu"
-        class="sc-bczRLJ dKgZvy sc-eCYdqJ henMfs"
+        class="navbar-button sc-bczRLJ dPfzAH"
         data-focus-visible="true"
         data-focused="true"
         data-pressed="true"
@@ -93,13 +95,13 @@ exports[`HelpMenu matches snapshot 1`] = `
   >
     <div
       aria-labelledby="react-aria-1"
-      class="sc-hKMtZM fKsRUv"
+      class="navbar-popover"
       data-placement="bottom"
       data-rac=""
       data-trigger="MenuTrigger"
       dir="ltr"
       role="dialog"
-      style="position: absolute; z-index: 100000; max-height: -24px; left: 12px; top: 8px;"
+      style="position: absolute; z-index: 100000; max-height: -24px; --navbar-popover-border-color: #63a524; left: 12px; top: 8px;"
       tabindex="-1"
     >
       <div
@@ -129,7 +131,7 @@ exports[`HelpMenu matches snapshot 1`] = `
         tabindex="-1"
       >
         <div
-          class="sc-gsnTZi sc-jSMfEi  bPmhIj"
+          class="navbar-menu-item sc-gsnTZi zbLGs"
           data-collection="react-aria-5"
           data-focus-visible="true"
           data-focused="true"
@@ -138,18 +140,20 @@ exports[`HelpMenu matches snapshot 1`] = `
           data-react-aria-pressable="true"
           id="react-aria-10"
           role="menuitem"
+          style="--navbar-menu-item-hover-bg: #f1f1f1; --navbar-menu-item-border-color: #f5f5f5;"
           tabindex="0"
         >
           Report an issue
         </div>
         <div
-          class="sc-gsnTZi sc-jSMfEi  bPmhIj"
+          class="navbar-menu-item sc-gsnTZi zbLGs"
           data-collection="react-aria-5"
           data-key="react-aria-2"
           data-rac=""
           data-react-aria-pressable="true"
           id="react-aria-14"
           role="menuitem"
+          style="--navbar-menu-item-hover-bg: #f1f1f1; --navbar-menu-item-border-color: #f5f5f5;"
           tabindex="-1"
         >
           Test Callback

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -1,0 +1,39 @@
+/* NavBar wrapper - portals to 'nav' slot */
+.navbar-wrapper {
+  overflow: visible;
+  z-index: var(--navbar-z-index, 10);
+  background: #ffffff;
+  position: relative;
+  padding: 0 var(--navbar-padding-mobile, 1.6rem);
+  box-shadow: 0 0.2rem 0.2rem 0 rgba(0, 0, 0, 0.1);
+  min-width: 0;
+}
+
+@media screen and (min-width: 75.0625em) {
+  .navbar-wrapper {
+    padding: 0 var(--navbar-padding-desktop, 3.2rem);
+  }
+}
+
+/* NavBar inner container */
+.navbar-bar {
+  overflow: visible;
+  display: flex;
+  justify-content: var(--navbar-justify-content, space-between);
+  align-items: center;
+  height: var(--navbar-height-mobile, 4rem);
+  max-width: var(--navbar-max-width);
+  margin: 0 auto;
+}
+
+@media screen and (min-width: 75.0625em) {
+  .navbar-bar {
+    height: var(--navbar-height-desktop, 4rem);
+  }
+}
+
+@media print {
+  .navbar-bar {
+    display: none;
+  }
+}

--- a/src/components/NavBar.stories.css
+++ b/src/components/NavBar.stories.css
@@ -1,0 +1,20 @@
+/* Styling for NavBar stories in Ladle */
+.story-navbar {
+  position: fixed;
+  left: 2rem;
+  top: 2rem;
+  width: calc(100% - 36rem);
+}
+
+.story-wrapper {
+  display: flex;
+  height: 100%;
+}
+
+.story-styled-menu-item {
+  color: #d4450c; /* colors.palette.orange */
+}
+
+.info-menu-button:hover svg path {
+  fill: var(--info-icon-fill, currentColor);
+}

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -10,25 +10,17 @@ import "./NavBar.stories.css";
 const dotsBase64 = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iNTYiIHZpZXdCb3g9IjAgMCAxMCA1NiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSI1IiBjeT0iNSIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSIyOCIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSI1MSIgcj0iNSIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4K";
 
 const InfoMenuButton = ({ children, ...props }: React.ComponentProps<typeof NavBarPopoverButton>) => {
-  const [isHovered, setIsHovered] = React.useState(false);
-
   return (
-    <div
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      style={{ height: '100%' }}
+    <NavBarPopoverButton
+      {...props}
+      style={{
+        '--info-icon-fill': colors.palette.lightBlue,
+        ...props.style
+      } as React.CSSProperties}
+      className="info-menu-button"
     >
-      <NavBarPopoverButton
-        {...props}
-        style={{
-          '--info-icon-fill': isHovered ? colors.palette.lightBlue : undefined,
-          ...props.style
-        } as React.CSSProperties}
-        className="info-menu-button"
-      >
-        {children}
-      </NavBarPopoverButton>
-    </div>
+      {children}
+    </NavBarPopoverButton>
   );
 };
 

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { CSSPropertiesWithVariables } from "../types";
 import { colors } from "../theme";
 import { NavBar } from "./NavBar";
 import { NavBarButton } from "./NavBarButton";
@@ -16,7 +17,7 @@ const InfoMenuButton = ({ children, ...props }: React.ComponentProps<typeof NavB
       style={{
         '--info-icon-fill': colors.palette.lightBlue,
         ...props.style
-      } as React.CSSProperties}
+      } as CSSPropertiesWithVariables}
       className="info-menu-button"
     >
       {children}

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -1,58 +1,58 @@
+import React from "react";
 import { colors } from "../theme";
-import styled from "styled-components";
 import { NavBar } from "./NavBar";
 import { NavBarButton } from "./NavBarButton";
 import { PopoverContainer, NavBarPopoverButton, NavBarMenuButton, NavBarMenuItem } from "./NavBarMenuButtons";
 import { Info } from "./svgs/Info";
 import { Tab, Tabs, TabList, TabPanel } from "./Tabs";
+import "./NavBar.stories.css";
 
 const dotsBase64 = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iNTYiIHZpZXdCb3g9IjAgMCAxMCA1NiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSI1IiBjeT0iNSIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSIyOCIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSI1MSIgcj0iNSIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4K";
 
-const InfoMenuButton = styled(NavBarPopoverButton)`
-  &:hover {
-    svg path {
-      fill: ${colors.palette.lightBlue};
-    }
-  }
-`;
+const InfoMenuButton = ({ children, ...props }: React.ComponentProps<typeof NavBarPopoverButton>) => {
+  const [isHovered, setIsHovered] = React.useState(false);
 
-const DotsMenuButton = styled(NavBarMenuButton)`
-  padding: 1rem;
-`;
+  return (
+    <div
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      style={{ height: '100%' }}
+    >
+      <NavBarPopoverButton
+        {...props}
+        style={{
+          '--info-icon-fill': isHovered ? colors.palette.lightBlue : undefined,
+          ...props.style
+        } as React.CSSProperties}
+        className="info-menu-button"
+      >
+        {children}
+      </NavBarPopoverButton>
+    </div>
+  );
+};
 
-const StyledNavBarMenuItem = styled(NavBarMenuItem)`
-  color: ${colors.palette.orange};
-`;
+const DotsMenuButton = (props: React.ComponentProps<typeof NavBarMenuButton>) => (
+  <NavBarMenuButton {...props} style={{ padding: '1rem', ...props.style }} />
+);
 
-const StyledWrapper = styled.div`
-  display: flex;
-  height: 100%
-`;
-
-const StyledNavBar = styled(NavBar)`
-  position: fixed;
-  left: 2rem;
-  top: 2rem;
-  width: calc(100% - 36rem);
-`;
-
-export const Plain = () => <StyledNavBar>NavBar</StyledNavBar>;
-export const LogoAndChildren = () => <StyledNavBar logo>Menu</StyledNavBar>;
-export const AltTextLinkedLogo = () => <StyledNavBar logo={{alt: 'custom alt', href: '/'}} />;
-export const AltTextNoLinkedLogo = () => <StyledNavBar logo={{alt: 'custom alt unlinked'}} />;
-export const OverrideJustifyContent = () => <StyledNavBar justifyContent='center'>
+export const Plain = () => <NavBar className="story-navbar">NavBar</NavBar>;
+export const LogoAndChildren = () => <NavBar logo className="story-navbar">Menu</NavBar>;
+export const AltTextLinkedLogo = () => <NavBar logo={{alt: 'custom alt', href: '/'}} className="story-navbar" />;
+export const AltTextNoLinkedLogo = () => <NavBar logo={{alt: 'custom alt unlinked'}} className="story-navbar" />;
+export const OverrideJustifyContent = () => <NavBar justifyContent='center' className="story-navbar">
   <strong>Centered Menu</strong>
-</StyledNavBar>;
+</NavBar>;
 
 export const Controls_NavBarButton = () =>
-  <StyledNavBar>
+  <NavBar className="story-navbar">
     <NavBarButton label="Help" />
     <NavBarButton label="Info" icon={<Info />} />
-    <NavBarButton style={{ padding: '1rem' }} icon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iNTYiIHZpZXdCb3g9IjAgMCAxMCA1NiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSI1IiBjeT0iNSIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSIyOCIgcj0iNSIgZmlsbD0iIzAwMCIvPgogIDxjaXJjbGUgY3g9IjUiIGN5PSI1MSIgcj0iNSIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4K" aria-label="Menu" />
-  </StyledNavBar>
+    <NavBarButton style={{ padding: '1rem' }} icon={dotsBase64} aria-label="Menu" />
+  </NavBar>
 
 export const PopoverAndMenu = () =>
-  <StyledNavBar>
+  <NavBar className="story-navbar">
     <InfoMenuButton label="Menu">
       <PopoverContainer>
         <button>Example button</button>
@@ -71,7 +71,7 @@ export const PopoverAndMenu = () =>
         <TabPanel id="three">Third</TabPanel>
       </Tabs>
     </InfoMenuButton>
-    <StyledWrapper>
+    <div className="story-wrapper">
       <NavBarMenuButton label="Help">
           <NavBarMenuItem>Open Guide</NavBarMenuItem>
           <NavBarMenuItem>Contact Support</NavBarMenuItem>
@@ -79,7 +79,7 @@ export const PopoverAndMenu = () =>
       <DotsMenuButton aria-label="Test menu" icon={dotsBase64}>
         <NavBarMenuItem>Cool menu item</NavBarMenuItem>
         <NavBarMenuItem>Really long menu item with a lot of text</NavBarMenuItem>
-        <StyledNavBarMenuItem>Styled menu item</StyledNavBarMenuItem>
+        <NavBarMenuItem className="story-styled-menu-item">Styled menu item</NavBarMenuItem>
       </DotsMenuButton>
-    </StyledWrapper>
-  </StyledNavBar>;
+    </div>
+  </NavBar>;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CSSPropertiesWithVariables } from '../types';
 import classNames from 'classnames';
 import * as Constants from '../constants';
 import theme from '../theme';
@@ -16,7 +17,7 @@ type NavBarProps = React.PropsWithChildren<{
   justifyContent?: string;
   ariaLabel?: string;
   className?: string;
-  style?: React.CSSProperties;
+  style?: CSSPropertiesWithVariables;
 }>
 
 export const NavBar = ({
@@ -35,19 +36,19 @@ export const NavBar = ({
   const {alt = 'OpenStax Logo', ...anchorProps} = logoIsObject ? logo : {};
   const logoComponent = logo ? <OpenstaxLogo alt={alt} /> : null;
 
-  const wrapperStyle = {
+  const wrapperStyle: CSSPropertiesWithVariables = {
     '--navbar-z-index': theme.zIndex.navbar,
     '--navbar-padding-mobile': `${theme.padding.navbar.mobile}rem`,
     '--navbar-padding-desktop': `${theme.padding.navbar.desktop}rem`,
     ...style
-  } as React.CSSProperties;
+  };
 
-  const barStyle = {
+  const barStyle: CSSPropertiesWithVariables = {
     '--navbar-max-width': maxWidth ? `${maxWidth}rem` : undefined,
     '--navbar-justify-content': justifyContent,
     '--navbar-height-mobile': `${navMobileHeight || Constants.navMobileHeight}rem`,
     '--navbar-height-desktop': `${navDesktopHeight || Constants.navDesktopHeight}rem`,
-  } as React.CSSProperties;
+  };
 
   return (
     <BodyPortal

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,40 +1,10 @@
-import styled from 'styled-components';
+import React from 'react';
+import classNames from 'classnames';
 import * as Constants from '../constants';
 import theme from '../theme';
 import { BodyPortal } from './BodyPortal';
 import { NavBarLogo as OpenstaxLogo } from './NavBarLogo';
-
-const BarWrapper = styled(BodyPortal)`
-  overflow: visible;
-  z-index: ${theme.zIndex.navbar};
-  background: ${theme.colors.palette.white};
-  position: relative;
-  padding: 0 ${theme.padding.navbar.mobile}rem;
-  box-shadow: 0 0.2rem 0.2rem 0 rgba(0, 0, 0, 0.1);
-  @media screen and (min-width: ${theme.breakpoints.desktopBreak}em) {
-    padding: 0 ${theme.padding.navbar.desktop}rem;
-  }
-  min-width: 0;
-`;
-
-const StyledNavBar = styled.div<{
-  maxWidth?: number;
-  navDesktopHeight: number;
-  navMobileHeight: number;
-  justifyContent?: string;
-}>`
-  overflow: visible;
-  display: flex;
-  justify-content: ${props => props.justifyContent || 'space-between'};
-  align-items: center;
-  height: ${props => props.navMobileHeight}rem;
-  ${props => props.maxWidth ? `max-width: ${props.maxWidth}rem;` : null}
-  margin: 0 auto;
-  @media screen and (min-width: ${theme.breakpoints.desktopBreak}em) {
-    height: ${props => props.navDesktopHeight}rem;
-  }
-  @media print { display: none; }
-`;
+import './NavBar.css';
 
 type Logo = React.HTMLProps<HTMLAnchorElement> & { alt?: string };
 
@@ -45,23 +15,53 @@ type NavBarProps = React.PropsWithChildren<{
   logo?: boolean | Logo;
   justifyContent?: string;
   ariaLabel?: string;
+  className?: string;
+  style?: React.CSSProperties;
 }>
 
-export const NavBar = ({ logo = false, maxWidth, navDesktopHeight, navMobileHeight, justifyContent, ariaLabel, ...props }: NavBarProps) => {
+export const NavBar = ({
+  logo = false,
+  maxWidth,
+  navDesktopHeight,
+  navMobileHeight,
+  justifyContent,
+  ariaLabel,
+  className,
+  style,
+  ...props
+}: NavBarProps) => {
   const logoIsObject = typeof logo === 'object';
   const renderAnchor = logoIsObject && 'href' in logo;
   const {alt = 'OpenStax Logo', ...anchorProps} = logoIsObject ? logo : {};
   const logoComponent = logo ? <OpenstaxLogo alt={alt} /> : null;
 
-  return <BarWrapper tagName='nav' ariaLabel={ariaLabel} slot='nav' {...props}>
-    <StyledNavBar
-      maxWidth={maxWidth}
-      navDesktopHeight={navDesktopHeight || Constants.navDesktopHeight}
-      navMobileHeight={navMobileHeight || Constants.navMobileHeight}
-      justifyContent={justifyContent}
+  const wrapperStyle = {
+    '--navbar-z-index': theme.zIndex.navbar,
+    '--navbar-padding-mobile': `${theme.padding.navbar.mobile}rem`,
+    '--navbar-padding-desktop': `${theme.padding.navbar.desktop}rem`,
+    ...style
+  } as React.CSSProperties;
+
+  const barStyle = {
+    '--navbar-max-width': maxWidth ? `${maxWidth}rem` : undefined,
+    '--navbar-justify-content': justifyContent,
+    '--navbar-height-mobile': `${navMobileHeight || Constants.navMobileHeight}rem`,
+    '--navbar-height-desktop': `${navDesktopHeight || Constants.navDesktopHeight}rem`,
+  } as React.CSSProperties;
+
+  return (
+    <BodyPortal
+      tagName='nav'
+      ariaLabel={ariaLabel}
+      slot='nav'
+      className={classNames('navbar-wrapper', className)}
+      style={wrapperStyle}
+      {...props}
     >
-      {renderAnchor ? <a {...anchorProps}>{logoComponent}</a> : logoComponent}
-      {props.children}
-    </StyledNavBar>
-  </BarWrapper>
+      <div className="navbar-bar" style={barStyle}>
+        {renderAnchor ? <a {...anchorProps}>{logoComponent}</a> : logoComponent}
+        {props.children}
+      </div>
+    </BodyPortal>
+  );
 };

--- a/src/components/NavBarButton.css
+++ b/src/components/NavBarButton.css
@@ -1,0 +1,23 @@
+/* NavBarButton base styles */
+.navbar-button {
+  border: none;
+  background: none;
+  padding: 0;
+  min-height: 4rem;
+  min-width: 4rem;
+  height: 100%;
+  display: inline-flex;
+  place-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.navbar-button img {
+  max-height: 100%;
+}
+
+.navbar-button img + *,
+.navbar-button svg + * {
+  margin-left: 0.8rem;
+}

--- a/src/components/NavBarButton.tsx
+++ b/src/components/NavBarButton.tsx
@@ -10,20 +10,22 @@ export type NavBarButtonProps = Omit<ButtonProps, "aria-label"> & {
   "aria-label"?: string;
 } & ({ label: string } | { "aria-label": string });
 
-export const NavBarButton = ({
-  label,
-  icon,
-  className,
-  "aria-label": ariaLabel,
-  ...props
-}: NavBarButtonProps) => (
-  <Button className={classNames("navbar-button", className)} aria-label={ariaLabel} {...props}>
-    {icon &&
-      (typeof icon === "string" ? (
-        <img aria-hidden="true" src={icon} alt="" />
-      ) : (
-        icon
-      ))}
-    {label ? <span>{label}</span> : null}
-  </Button>
+export const NavBarButton = React.forwardRef<React.ElementRef<typeof Button>, NavBarButtonProps>(
+  ({ label, icon, className, "aria-label": ariaLabel, ...props }, ref) => (
+    <Button
+      ref={ref}
+      className={classNames("navbar-button", className)}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {icon &&
+        (typeof icon === "string" ? (
+          <img aria-hidden="true" src={icon} alt="" />
+        ) : (
+          icon
+        ))}
+      {label ? <span>{label}</span> : null}
+    </Button>
+  )
 );
+NavBarButton.displayName = "NavBarButton";

--- a/src/components/NavBarButton.tsx
+++ b/src/components/NavBarButton.tsx
@@ -1,5 +1,7 @@
+import React from "react";
 import { Button, ButtonProps } from "react-aria-components";
-import styled from "styled-components";
+import classNames from "classnames";
+import "./NavBarButton.css";
 
 export type NavBarButtonProps = Omit<ButtonProps, "aria-label"> & {
   label?: string;
@@ -8,43 +10,20 @@ export type NavBarButtonProps = Omit<ButtonProps, "aria-label"> & {
   "aria-label"?: string;
 } & ({ label: string } | { "aria-label": string });
 
-export const NavBarButton = styled(
-  ({
-    label,
-    icon,
-    className,
-    "aria-label": ariaLabel,
-    ...props
-  }: NavBarButtonProps) => (
-    <Button className={className} aria-label={ariaLabel} {...props}>
-      {icon &&
-        (typeof icon === "string" ? (
-          <img aria-hidden="true" src={icon} alt="" />
-        ) : (
-          icon
-        ))}
-      {label ? <span>{label}</span> : null}
-    </Button>
-  ),
-)`
-  border: none;
-  background: none;
-  padding: 0;
-  min-height: 4rem;
-  min-width: 4rem;
-  height: 100%;
-  display: inline-flex;
-  place-content: center;
-  align-items: center;
-  cursor: pointer;
-  font-weight: 500;
-
-  img {
-    max-height: 100%;
-  }
-
-  img + *,
-  svg + * {
-    margin-left: 0.8rem;
-  }
-`;
+export const NavBarButton = ({
+  label,
+  icon,
+  className,
+  "aria-label": ariaLabel,
+  ...props
+}: NavBarButtonProps) => (
+  <Button className={classNames("navbar-button", className)} aria-label={ariaLabel} {...props}>
+    {icon &&
+      (typeof icon === "string" ? (
+        <img aria-hidden="true" src={icon} alt="" />
+      ) : (
+        icon
+      ))}
+    {label ? <span>{label}</span> : null}
+  </Button>
+);

--- a/src/components/NavBarMenuButtons.css
+++ b/src/components/NavBarMenuButtons.css
@@ -6,7 +6,7 @@
 /* NavBar Popover */
 .navbar-popover {
   margin-top: -1rem;
-  border-top: 0.4rem solid var(--navbar-popover-border-color, #009664);
+  border-top: 0.4rem solid var(--navbar-popover-border-color, #63a524);
   box-shadow: 0 0.4rem 0.4rem 0 #00000033;
   background: #fff;
 }
@@ -24,7 +24,7 @@
 .navbar-menu-item:hover,
 .navbar-menu-item[data-hovered],
 .navbar-menu-item[data-focused] {
-  background: var(--navbar-menu-item-hover-bg, #f5f5f5);
+  background: var(--navbar-menu-item-hover-bg, #f1f1f1);
 }
 
 .navbar-menu-item:focus-visible {
@@ -38,5 +38,5 @@
 }
 
 .navbar-menu-item:not(:last-child) {
-  border-bottom: 0.1rem solid var(--navbar-menu-item-border-color, #e9e9e9);
+  border-bottom: 0.1rem solid var(--navbar-menu-item-border-color, #f5f5f5);
 }

--- a/src/components/NavBarMenuButtons.css
+++ b/src/components/NavBarMenuButtons.css
@@ -1,0 +1,42 @@
+/* NavBar Popover Container */
+.navbar-popover-container {
+  padding: 1.6rem;
+}
+
+/* NavBar Popover */
+.navbar-popover {
+  margin-top: -1rem;
+  border-top: 0.4rem solid var(--navbar-popover-border-color, #009664);
+  box-shadow: 0 0.4rem 0.4rem 0 #00000033;
+  background: #fff;
+}
+
+/* NavBar Menu Item */
+.navbar-menu-item {
+  font-size: 1.6rem;
+  min-height: 4rem;
+  padding: 0 1.6rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.navbar-menu-item:hover,
+.navbar-menu-item[data-hovered],
+.navbar-menu-item[data-focused] {
+  background: var(--navbar-menu-item-hover-bg, #f5f5f5);
+}
+
+.navbar-menu-item:focus-visible {
+  outline: 0.2rem auto Highlight;
+  outline: 0.2rem auto -webkit-focus-ring-color;
+  outline-offset: -0.2rem;
+}
+
+.navbar-menu-item:active {
+  font-weight: bold;
+}
+
+.navbar-menu-item:not(:last-child) {
+  border-bottom: 0.1rem solid var(--navbar-menu-item-border-color, #e9e9e9);
+}

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -29,9 +29,13 @@ export const NavBarMenuItem = ({ className, style, ...props }: React.ComponentPr
   );
 };
 
-export const PopoverContainer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
-  <div className={classNames("navbar-popover-container", className)} {...props} />
-);
+export const PopoverContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={classNames("navbar-popover-container", className)} {...props} />
+));
+PopoverContainer.displayName = "PopoverContainer";
 
 export const NavBarPopover = ({ className, style, ...props }: PopoverProps) => {
   const popoverStyle = {

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -13,7 +13,10 @@ import { colors } from "../theme";
 import { NavBarButton, NavBarButtonProps } from "./NavBarButton";
 import "./NavBarMenuButtons.css";
 
-export const NavBarMenuItem = ({ className, style, ...props }: React.ComponentProps<typeof MenuItem>) => {
+export const NavBarMenuItem = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof MenuItem>
+>(({ className, style, ...props }, ref) => {
   const menuItemStyle = {
     '--navbar-menu-item-hover-bg': colors.palette.neutralLighter,
     '--navbar-menu-item-border-color': colors.palette.neutralBright,
@@ -22,12 +25,14 @@ export const NavBarMenuItem = ({ className, style, ...props }: React.ComponentPr
 
   return (
     <MenuItem
+      ref={ref}
       className={classNames("navbar-menu-item", className)}
       style={menuItemStyle}
       {...props}
     />
   );
-};
+});
+NavBarMenuItem.displayName = "NavBarMenuItem";
 
 export const PopoverContainer = React.forwardRef<
   HTMLDivElement,
@@ -37,7 +42,10 @@ export const PopoverContainer = React.forwardRef<
 ));
 PopoverContainer.displayName = "PopoverContainer";
 
-export const NavBarPopover = ({ className, style, ...props }: PopoverProps) => {
+export const NavBarPopover = React.forwardRef<
+  HTMLDivElement,
+  PopoverProps
+>(({ className, style, ...props }, ref) => {
   const popoverStyle = {
     '--navbar-popover-border-color': colors.palette.darkGreen,
     ...style
@@ -45,12 +53,14 @@ export const NavBarPopover = ({ className, style, ...props }: PopoverProps) => {
 
   return (
     <Popover
+      ref={ref}
       className={classNames("navbar-popover", className)}
       style={popoverStyle}
       {...props}
     />
   );
-};
+});
+NavBarPopover.displayName = "NavBarPopover";
 
 export type NavBarBaseButtonProps = React.PropsWithChildren<{
   popoverProps?: PopoverProps;

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 import {
   Dialog,
   DialogTrigger,
@@ -8,50 +9,44 @@ import {
   Popover,
   PopoverProps,
 } from "react-aria-components";
-import styled from "styled-components";
-import { colors, defaultFocusOutline } from "../theme";
+import { colors } from "../theme";
 import { NavBarButton, NavBarButtonProps } from "./NavBarButton";
+import "./NavBarMenuButtons.css";
 
-export const NavBarMenuItem = styled(MenuItem)``;
+export const NavBarMenuItem = ({ className, style, ...props }: React.ComponentProps<typeof MenuItem>) => {
+  const menuItemStyle = {
+    '--navbar-menu-item-hover-bg': colors.palette.neutralLighter,
+    '--navbar-menu-item-border-color': colors.palette.neutralBright,
+    ...style
+  } as React.CSSProperties;
 
-export const PopoverContainer = styled.div`
-  padding: 1.6rem;
-`;
+  return (
+    <MenuItem
+      className={classNames("navbar-menu-item", className)}
+      style={menuItemStyle}
+      {...props}
+    />
+  );
+};
 
-export const NavBarPopover = styled(Popover)`
-  margin-top: -1rem;
-  border-top: 0.4rem solid ${colors.palette.darkGreen};
-  box-shadow: 0 0.4rem 0.4rem 0 #00000033;
-  background: #fff;
+export const PopoverContainer = ({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
+  <div className={classNames("navbar-popover-container", className)} {...props} />
+);
 
-  ${NavBarMenuItem} {
-    font-size: 1.6rem;
-    min-height: 4rem;
-    padding: 0 1.6rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
+export const NavBarPopover = ({ className, style, ...props }: PopoverProps) => {
+  const popoverStyle = {
+    '--navbar-popover-border-color': colors.palette.darkGreen,
+    ...style
+  } as React.CSSProperties;
 
-    &:hover,
-    &[data-hovered],
-    &[data-focused] {
-      background: ${colors.palette.neutralLighter};
-    }
-
-    &:focus-visible {
-      ${defaultFocusOutline}
-      outline-offset: -0.2rem;
-    }
-
-    &:active {
-      font-weight: bold;
-    }
-
-    &:not(:last-child) {
-      border-bottom: 0.1rem solid ${colors.palette.neutralBright};
-    }
-  }
-`;
+  return (
+    <Popover
+      className={classNames("navbar-popover", className)}
+      style={popoverStyle}
+      {...props}
+    />
+  );
+};
 
 export type NavBarBaseButtonProps = React.PropsWithChildren<{
   popoverProps?: PopoverProps;

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -18,7 +18,7 @@ export const NavBarMenuItem = ({ className, style, ...props }: React.ComponentPr
     '--navbar-menu-item-hover-bg': colors.palette.neutralLighter,
     '--navbar-menu-item-border-color': colors.palette.neutralBright,
     ...style
-  } as React.CSSProperties;
+  } as unknown as React.CSSProperties;
 
   return (
     <MenuItem
@@ -37,7 +37,7 @@ export const NavBarPopover = ({ className, style, ...props }: PopoverProps) => {
   const popoverStyle = {
     '--navbar-popover-border-color': colors.palette.darkGreen,
     ...style
-  } as React.CSSProperties;
+  } as unknown as React.CSSProperties;
 
   return (
     <Popover

--- a/src/components/NavBarMenuButtons.tsx
+++ b/src/components/NavBarMenuButtons.tsx
@@ -11,17 +11,18 @@ import {
 } from "react-aria-components";
 import { colors } from "../theme";
 import { NavBarButton, NavBarButtonProps } from "./NavBarButton";
+import { CSSPropertiesWithVariables } from "../types";
 import "./NavBarMenuButtons.css";
 
 export const NavBarMenuItem = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof MenuItem>
 >(({ className, style, ...props }, ref) => {
-  const menuItemStyle = {
+  const menuItemStyle: CSSPropertiesWithVariables = {
     '--navbar-menu-item-hover-bg': colors.palette.neutralLighter,
     '--navbar-menu-item-border-color': colors.palette.neutralBright,
     ...style
-  } as unknown as React.CSSProperties;
+  };
 
   return (
     <MenuItem
@@ -46,10 +47,10 @@ export const NavBarPopover = React.forwardRef<
   HTMLDivElement,
   PopoverProps
 >(({ className, style, ...props }, ref) => {
-  const popoverStyle = {
+  const popoverStyle: CSSPropertiesWithVariables = {
     '--navbar-popover-border-color': colors.palette.darkGreen,
     ...style
-  } as unknown as React.CSSProperties;
+  };
 
   return (
     <Popover

--- a/src/components/ProfileMenu/__snapshots__/index.spec.tsx.snap
+++ b/src/components/ProfileMenu/__snapshots__/index.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`ProfileMenu matches snapshot with user initials 1`] = `
       aria-expanded="true"
       aria-haspopup="true"
       aria-label="Account actions"
-      class="sc-eCYdqJ izrTAJ"
+      class="sc-bczRLJ fSHaly"
       data-focus-visible="true"
       data-focused="true"
       data-pressed="true"
@@ -39,13 +39,13 @@ exports[`ProfileMenu matches snapshot with user initials 1`] = `
   >
     <div
       aria-labelledby="react-aria-1"
-      class="sc-hKMtZM sc-jSMfEi fKsRUv bCatnj"
+      class="navbar-popover sc-gsnTZi ldbTAg"
       data-placement="bottom"
       data-rac=""
       data-trigger="MenuTrigger"
       dir="ltr"
       role="dialog"
-      style="position: absolute; z-index: 100000; max-height: -24px; left: 12px; top: 8px;"
+      style="position: absolute; z-index: 100000; max-height: -24px; --navbar-popover-border-color: #63a524; left: 12px; top: 8px;"
       tabindex="-1"
     >
       <div
@@ -75,7 +75,7 @@ exports[`ProfileMenu matches snapshot with user initials 1`] = `
         tabindex="-1"
       >
         <div
-          class="sc-gsnTZi sc-gKXOVf  jjVNxD"
+          class="navbar-menu-item sc-dkzDqf jhxreu"
           data-collection="react-aria-5"
           data-focus-visible="true"
           data-focused="true"
@@ -84,18 +84,20 @@ exports[`ProfileMenu matches snapshot with user initials 1`] = `
           data-react-aria-pressable="true"
           id="react-aria-10"
           role="menuitem"
+          style="--navbar-menu-item-hover-bg: #f1f1f1; --navbar-menu-item-border-color: #f5f5f5;"
           tabindex="0"
         >
           Profile
         </div>
         <div
-          class="sc-gsnTZi sc-gKXOVf  jjVNxD"
+          class="navbar-menu-item sc-dkzDqf jhxreu"
           data-collection="react-aria-5"
           data-key="logout"
           data-rac=""
           data-react-aria-pressable="true"
           id="react-aria-14"
           role="menuitem"
+          style="--navbar-menu-item-hover-bg: #f1f1f1; --navbar-menu-item-border-color: #f5f5f5;"
           tabindex="-1"
         >
           Log out

--- a/src/components/__snapshots__/NavBar.spec.tsx.snap
+++ b/src/components/__snapshots__/NavBar.spec.tsx.snap
@@ -6,11 +6,13 @@ exports[`NavBar matches snapshot 1`] = `
     id="root"
   />
   <nav
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi kxMJGL"
+      class="navbar-bar"
+      style="--navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       NavBar content
     </div>
@@ -25,11 +27,13 @@ exports[`NavBar sets the ariaLabel 1`] = `
   />
   <nav
     aria-label="test"
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi eXUcQI"
+      class="navbar-bar"
+      style="--navbar-max-width: 128rem; --navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       NavBar content
     </div>
@@ -43,11 +47,13 @@ exports[`NavBar sets the maxWidth 1`] = `
     id="root"
   />
   <nav
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi eXUcQI"
+      class="navbar-bar"
+      style="--navbar-max-width: 128rem; --navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       NavBar content
     </div>
@@ -61,11 +67,13 @@ exports[`NavBar with a logo customizes the alt text 1`] = `
     id="root"
   />
   <nav
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi kxMJGL"
+      class="navbar-bar"
+      style="--navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       <svg
         class="navbar-logo"
@@ -119,11 +127,13 @@ exports[`NavBar with a logo links the logo 1`] = `
     id="root"
   />
   <nav
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi kxMJGL"
+      class="navbar-bar"
+      style="--navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       <a
         href="/"
@@ -181,11 +191,13 @@ exports[`NavBar with a logo matches snapshot 1`] = `
     id="root"
   />
   <nav
-    class="sc-bczRLJ czHLRx"
+    class="navbar-wrapper"
     data-portal-slot="nav"
+    style="--navbar-z-index: 10; --navbar-padding-mobile: 1.6rem; --navbar-padding-desktop: 3.2rem;"
   >
     <div
-      class="sc-gsnTZi kxMJGL"
+      class="navbar-bar"
+      style="--navbar-height-mobile: 4rem; --navbar-height-desktop: 4rem;"
     >
       <svg
         class="navbar-logo"

--- a/src/components/__snapshots__/NavBarButton.spec.tsx.snap
+++ b/src/components/__snapshots__/NavBarButton.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NavBarButton matches base64 icon snapshot 1`] = `
 <button
   aria-label="dots menu"
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-5"
@@ -33,7 +33,7 @@ exports[`NavBarButton matches base64 icon snapshot 1`] = `
 
 exports[`NavBarButton matches icon and text snapshot 1`] = `
 <button
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-7"
@@ -74,7 +74,7 @@ exports[`NavBarButton matches icon and text snapshot 1`] = `
 exports[`NavBarButton matches svg icon snapshot 1`] = `
 <button
   aria-label="info"
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-3"
@@ -111,7 +111,7 @@ exports[`NavBarButton matches svg icon snapshot 1`] = `
 
 exports[`NavBarButton matches text snapshot 1`] = `
 <button
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-1"

--- a/src/components/__snapshots__/NavBarMenuButtons.spec.tsx.snap
+++ b/src/components/__snapshots__/NavBarMenuButtons.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`NavBarMenuButton matches snapshot 1`] = `
 <button
   aria-expanded={false}
   aria-haspopup={true}
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-7"
@@ -34,7 +34,7 @@ exports[`NavBarPopoverButton matches custom aria label snapshot 1`] = `
 <button
   aria-expanded={false}
   aria-label="Custom label"
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-5"
@@ -63,7 +63,7 @@ exports[`NavBarPopoverButton matches custom aria label snapshot 1`] = `
 exports[`NavBarPopoverButton matches snapshot 1`] = `
 <button
   aria-expanded={false}
-  className="sc-bczRLJ dKgZvy"
+  className="navbar-button"
   data-rac=""
   data-react-aria-pressable={true}
   id="react-aria-2"

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,3 +8,5 @@ if (typeof performance.getEntriesByType !== 'function') {
 if (typeof performance.getEntriesByName !== 'function') {
   performance.getEntriesByName = () => [];
 }
+
+export {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 export type ToastData = {
   id?: string;
   title: string;
@@ -14,4 +16,8 @@ export type SentryError = {
   componentStack?: string;
   eventId?: string;
   type?: string;
+};
+
+export type CSSPropertiesWithVariables = CSSProperties & {
+  [key: `--${string}`]: string | number | undefined;
 };


### PR DESCRIPTION
## Summary

Migrates NavBar components from styled-components to plain CSS with CSS variables for theme binding.

### Components Migrated
- **NavBar.tsx** - Main navigation bar component
- **NavBarButton.tsx** - Button component for navbar
- **NavBarMenuButtons.tsx** - Menu/Popover button components

### Changes Made
- Created `NavBar.css`, `NavBarButton.css`, and `NavBarMenuButtons.css`
- Replaced styled-components with classNames and CSS custom properties
- Updated `NavBar.stories.tsx` to use plain CSS
- All components maintain backward compatibility at React API level
- Theme values bound via CSS variables with fallback defaults

### Migration Pattern
Following the established pattern from Button.tsx migration:
- CSS files define base styles with CSS custom properties
- Components bind theme values to style props as CSS variables  
- `classNames` library used for conditional styling
- Media queries converted to standard CSS @media syntax

### Related
- Jira: [CORE-2004](https://openstax.atlassian.net/browse/CORE-2004)
- Part of larger styled-components to plain CSS migration effort

### Testing Notes
- All existing Ladle stories updated and working
- Components support className and style prop spreading
- Visual appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2004]: https://openstax.atlassian.net/browse/CORE-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ