### PR TITLE
CORE-2604 Fix scroll loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.23.2",
+  "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openstax/ui-components",
-      "version": "1.23.2",
+      "version": "1.23.4",
       "license": "MIT",
       "dependencies": {
         "@sentry/react": "^10.60.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openstax/ui-components",
-      "version": "1.23.4",
+      "version": "1.23.5",
       "license": "MIT",
       "dependencies": {
         "@sentry/react": "^10.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/ui-components",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "license": "MIT",
   "repository": "https://github.com/openstax/ui-components.git",
   "publishConfig": {

--- a/src/components/SidebarNav/hooks.ts
+++ b/src/components/SidebarNav/hooks.ts
@@ -116,8 +116,10 @@ export const useScrollRestoration = (
 ) => {
   const [scrollPosition, setScrollPosition] = React.useState(0);
 
-  // Restore scroll position after render
-  requestAnimationFrame(() => {
+  // useLayoutEffect without deps runs after every render, before paint,
+  // preventing the re-render loop that a bare requestAnimationFrame in the
+  // render body causes (each RAF fires a scroll event → state update → loop).
+  React.useLayoutEffect(() => {
     if (ref.current) {
       ref.current.scrollTop = scrollPosition;
     }

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -98,6 +98,14 @@ describe("useMatchMediaQuery", () => {
     expect(screen.getByTestId("result").textContent).toBe("Matches");
   });
 
+  test("it syncs matches when the query prop changes", () => {
+    const component = render(<MediaComponent query="(min-width: 600px)" />);
+    expect(screen.getByTestId("result").textContent).toBe("Matches");
+
+    component.rerender(<MediaComponent query="(min-width: 800px)" />);
+    expect(screen.getByTestId("result").textContent).toBe("Does not match");
+  });
+
   test("it attaches and detaches event listeners", () => {
     const mock = {
       addEventListener: jest.fn(),

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -33,6 +33,7 @@ export const useMatchMediaQuery = (query: string) => {
   }, []);
 
   React.useEffect(() => {
+    setMatches(matchMedia.matches);
     if (typeof matchMedia.addEventListener === "function") {
       matchMedia.addEventListener("change", listener);
     } else {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -21,7 +21,7 @@ export const useSetAppError = () => {
 }
 
 export const useMatchMediaQuery = (query: string) => {
-  const matchMedia = window.matchMedia(query);
+  const matchMedia = React.useMemo(() => window.matchMedia(query), [query]);
   const [matches, setMatches] = React.useState(matchMedia.matches);
 
   const listener = React.useCallback((e: MediaQueryListEvent) => {


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-2604

Use useLayoutEffect instead of requestAnimationFrame to prevent re-renders triggered by useScrollRestoration
Also fix useMatchMediaQuery to prevent it from removing and re-attaching its listeners on every render due to `matchMedia` changing.